### PR TITLE
Adds Races to the Game

### DIFF
--- a/migrations/dev/Version20260403091622.php
+++ b/migrations/dev/Version20260403091622.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace DoctrineMigrations\Dev;
+
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+use LotGD2\Doctrine\MySQLDependentTransactionalTrait;
+
+final class Version20260403091622 extends AbstractMigration
+{
+    use MySQLDependentTransactionalTrait;
+
+    public function getDescription(): string
+    {
+        return 'Adds a table for races';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $raceTable = $schema->createTable("race");
+        $raceTable->addColumn("id", Types::INTEGER)->setAutoincrement(true)->setNotnull(true);
+        $raceTable->addColumn("name", Types::STRING)->setLength(255)->setNotnull(true);
+        $raceTable->addColumn("description", Types::TEXT)->setNotnull(true);
+        $raceTable->addColumn("selection_text", Types::TEXT)->setNotnull(true);
+        $raceTable->addColumn("class_name", Types::STRING)->setLength(255)->setNotnull(true);
+        $raceTable->addColumn("configuration", Types::JSONB)->setNotnull(true);
+
+        $raceTable->addPrimaryKeyConstraint(PrimaryKeyConstraint::editor()->setUnquotedColumnNames("id")->create());
+        $raceTable->addIndex(["name"], "IDX_DA6FBBAF5E237E06");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable("race");
+    }
+}

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -3,5 +3,6 @@ parameters:
     level: 6
     paths:
         - src/
+        - migrations/
     doctrine:
         allowNullablePropertyForRequiredField: true

--- a/src/Controller/GameController.php
+++ b/src/Controller/GameController.php
@@ -17,8 +17,13 @@ class GameController extends AbstractController
     #[IsGranted("ROLE_USER")]
     public function view(
         GameLoop $gameLoop,
-        Character $character,
+        ?Character $character = null,
     ): Response {
+        if (null === $character) {
+            $this->addFlash("critical", "Character disappeared");
+            return $this->redirectToRoute("lotgd_main");
+        }
+
         $gameLoop->setCharacter($character);
 
         return $this->render("game/view.html.twig", [

--- a/src/DataFixtures/RaceFixtures.php
+++ b/src/DataFixtures/RaceFixtures.php
@@ -29,7 +29,71 @@ class RaceFixtures extends Fixture
                 configuration: [
                     "turns" => 1,
                 ],
-            )
+            ),
+            new Race(
+                name: "Dwarf",
+                description: <<<TEXT
+                    You are from the depths of subterranean strongholds of Qexelcrag, home to the noble and fierce Dwarven 
+                    people whose desire for privacy and treasure bears no resemblance to their tiny stature.
+                    TEXT,
+                selectionText: <<<TXT
+                    As a dwarf, you are more easily able to identify the value of certain goods.
+                    
+                    You gain extra gold from forest fights!
+                    TXT,
+                className: StandardRace::class,
+                configuration: [
+                    "goldFactor" => 1.2,
+                ],
+            ),
+            new Race(
+                name: "Elf",
+                description: <<<TEXT
+                    You grew up high among the trees of the Glorfindal forest, in frail looking elaborate Elvish structures 
+                    that look as though they might collapse under the slightest strain, yet have existed for centuries.
+                    TEXT,
+                selectionText: <<<TXT
+                    As an elf, you are keenly aware of your surroundings at all times; very little ever catches you by surprise.
+                    
+                    You gain extra defense!
+                    TXT,
+                className: StandardRace::class,
+                configuration: [
+                    "defense" => 1,
+                ],
+            ),
+            new Race(
+                name: "Troll",
+                description: <<<TEXT
+                    You are from the swamps of Glukmoore as a Troll, fending for yourself from the very moment you crept 
+                    out of your leathery egg, slaying your yet unhatched siblings, and feasting on their bones.
+                    TEXT,
+                selectionText: <<<TXT
+                    As a troll, and having always fended for yourself, the ways of battle are not foreign to you.
+                    
+                    You gain extra attack!!
+                    TXT,
+                className: StandardRace::class,
+                configuration: [
+                    "attack" => 1,
+                ],
+            ),
+            new Race(
+                name: "Lizard",
+                description: <<<TEXT
+                    You hatched from your egg in a hole somewhere on a barren field, beyond any civilization. 
+                    Related to dragons, you have a hard live.
+                    TEXT,
+                selectionText: <<<TXT
+                    As a lizard, your regular skin shedding give you a substantial advantage for your health compared to other races.
+                    
+                    You start with more health!
+                    TXT,
+                className: StandardRace::class,
+                configuration: [
+                    "health" => 2,
+                ],
+            ),
         ];
 
         array_map(fn (Race $race) => $manager->persist($race), $races);

--- a/src/DataFixtures/RaceFixtures.php
+++ b/src/DataFixtures/RaceFixtures.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use LotGD2\Entity\Mapped\Race;
+use LotGD2\Game\Race\StandardRace;
+
+class RaceFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $races = [
+            new Race(
+                name: "Human",
+                description: <<<TEXT
+                    You grew up on the plains around the city of Romar, the city of men; always following your father and looking up to 
+                    his every move, until he sought out the Green Dragon, never to be seen again.
+                    TEXT,
+                selectionText: <<<TXT
+                    As a human, your size and strength permit you the ability to effortlessly wield weapons, tiring much 
+                    less quickly than other races.
+                    
+                    You gain one extra turn each day!
+                    TXT,
+                className: StandardRace::class,
+                configuration: [
+                    "turns" => 1,
+                ],
+            )
+        ];
+
+        array_map(fn (Race $race) => $manager->persist($race), $races);
+        $manager->flush();
+    }
+}

--- a/src/DataFixtures/UserAndCharacterFixtures.php
+++ b/src/DataFixtures/UserAndCharacterFixtures.php
@@ -5,8 +5,12 @@ namespace LotGD2\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use LotGD2\Entity\Character\EquipmentItem;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Mapped\User;
+use LotGD2\Game\Character\Equipment;
+use LotGD2\Game\Character\Health;
+use LotGD2\Game\Character\Stats;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class UserAndCharacterFixtures extends Fixture
@@ -31,16 +35,73 @@ class UserAndCharacterFixtures extends Fixture
                 name: "T. Sandmeyer",
                 title: "Charged",
                 level: 9,
+                properties: [
+                    Health::HealthPropertyName => 90,
+                    Health::MaxHealthPropertyName => 90,
+                    Health::Age => 67,
+                    Stats::AttackPropertyName => 9,
+                    Stats::DefensePropertyName => 9,
+                    Equipment::PropertyName => [
+                        Equipment::WeaponSlot => new EquipmentItem(
+                            name: "Bottle of sodium nitrite",
+                            strength: 9,
+                            value: 4230,
+                        ),
+                        Equipment::ArmorSlot => new EquipmentItem(
+                            name: "Blast shield",
+                            strength: 9,
+                            value: 4230,
+                        ),
+                    ],
+                ],
             ),
             new Character(
                 name: "A. Suzuki",
                 title: "Sensei",
                 level: 14,
+                properties: [
+                    Health::HealthPropertyName => 140,
+                    Health::MaxHealthPropertyName => 140,
+                    Health::Age => 80,
+                    Stats::AttackPropertyName => 14,
+                    Stats::DefensePropertyName => 14,
+                    Equipment::PropertyName => [
+                        Equipment::WeaponSlot => new EquipmentItem(
+                            name: "Transmetallation",
+                            strength: 14,
+                            value: 9000,
+                        ),
+                        Equipment::ArmorSlot => new EquipmentItem(
+                            name: "Phosphine Ligand",
+                            strength: 14,
+                            value: 9000,
+                        ),
+                    ],
+                ],
             ),
             new Character(
                 name: "M. Disney",
                 title: "Master",
                 level: 15,
+                properties: [
+                    Health::HealthPropertyName => 150,
+                    Health::MaxHealthPropertyName => 150,
+                    Health::Age => 71,
+                    Stats::AttackPropertyName => 15,
+                    Stats::DefensePropertyName => 15,
+                    Equipment::PropertyName => [
+                        Equipment::WeaponSlot => new EquipmentItem(
+                            name: "mRNA",
+                            strength: 15,
+                            value: 10350,
+                        ),
+                        Equipment::ArmorSlot => new EquipmentItem(
+                            name: "siRNA",
+                            strength: 15,
+                            value: 10350,
+                        ),
+                    ],
+                ],
             ),
         ];
     }

--- a/src/Entity/Battle/CurrentCharacterFighter.php
+++ b/src/Entity/Battle/CurrentCharacterFighter.php
@@ -15,7 +15,7 @@ class CurrentCharacterFighter extends Fighter
     ): self {
         $health = new Health(null, $character);
         $equipment = new Equipment(null, $character);
-        $stats = new Stats(null, $equipment, $health, $character);
+        $stats = new Stats(null, $equipment, $character);
 
         $fighter =  new CurrentCharacterFighter(
             name: $character->name,

--- a/src/Entity/Mapped/Character.php
+++ b/src/Entity/Mapped/Character.php
@@ -7,11 +7,12 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Dunglas\DoctrineJsonOdm\Type\JsonDocumentType;
 use LotGD2\Repository\CharacterRepository;
+use Stringable;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: CharacterRepository::class)]
 #[ORM\Table(name: '`character`')]
-class Character
+class Character implements Stringable
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -74,6 +75,11 @@ class Character
             set => $value;
         },
     ) {
+    }
+
+    public function __toString(): string
+    {
+        return "<Character#{$this->id}, {$this->name}>";
     }
 
     public function getProperty(string $name, mixed $default = null): mixed

--- a/src/Entity/Mapped/Race.php
+++ b/src/Entity/Mapped/Race.php
@@ -75,6 +75,6 @@ class Race implements Stringable
 
     public function __toString(): string
     {
-        return "<Character#{$this->id} {$this->name}>";
+        return "<Race#{$this->id} {$this->name}>";
     }
 }

--- a/src/Entity/Mapped/Race.php
+++ b/src/Entity/Mapped/Race.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Dunglas\DoctrineJsonOdm\Type\JsonDocumentType;
 use LotGD2\Game\Race\RaceInterface;
 use LotGD2\Repository\RaceRepository;
+use Stringable;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -15,7 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 #[ORM\Entity(repositoryClass: RaceRepository::class)]
 #[ORM\Index(fields: ["name"])]
-class Race
+class Race implements Stringable
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -70,5 +71,10 @@ class Race
         }
     ) {
 
+    }
+
+    public function __toString(): string
+    {
+        return "<Character#{$this->id} {$this->name}>";
     }
 }

--- a/src/Entity/Mapped/Race.php
+++ b/src/Entity/Mapped/Race.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Entity\Mapped;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Dunglas\DoctrineJsonOdm\Type\JsonDocumentType;
+use LotGD2\Game\Race\RaceInterface;
+use LotGD2\Repository\RaceRepository;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @template TConfig of array<string, mixed> = array<string, mixed>
+ */
+#[ORM\Entity(repositoryClass: RaceRepository::class)]
+#[ORM\Index(fields: ["name"])]
+class Race
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private(set) ?int $id = null;
+
+    /**
+     * @param string|null $name
+     * @param string|null $description
+     * @param string|null $selectionText
+     * @param null|class-string<RaceInterface<TConfig>> $className
+     * @param array $configuration
+     */
+    public function __construct(
+        #[ORM\Column(length: 255)]
+        #[Assert\NotBlank()]
+        public ?string $name = null {
+            get => $this->name;
+            set => $value;
+        },
+
+        #[ORM\Column(type: Types::TEXT)]
+        #[Assert\NotBlank()]
+        public ?string $description = null {
+            get => $this->description;
+            set => $value;
+        },
+
+        #[ORM\Column(type: Types::TEXT)]
+        #[Assert\NotBlank()]
+        public ?string $selectionText = null {
+            get => $this->selectionText;
+            set => $value;
+        },
+
+        // @phpstan-ignore doctrine.columnType
+        #[ORM\Column(length: 255)]
+        #[Assert\NotBlank()]
+        public ?string $className = null {
+            get => $this->className;
+            set => $value;
+        },
+
+        /**
+         * @var TConfig
+         */
+        #[ORM\Column(type: Types::JSONB)]
+        #[Assert\NotBlank()]
+        public array $configuration = [] {
+            get => $this->configuration;
+            set => $value;
+        }
+    ) {
+
+    }
+}

--- a/src/Entity/Mapped/Stage.php
+++ b/src/Entity/Mapped/Stage.php
@@ -136,6 +136,11 @@ class Stage
 
         if (array_key_exists($actionGroupId, $this->actionGroups)) {
             $this->actionGroups[$actionGroupId]->addAction($action);
+        } else {
+            throw new \ValueError(<<<TXT
+                Action group $actionGroupId does not exist. If you cleared action groups with clearActionGroup, remember 
+                to add actions groups yourself. Or use the ActionService->resetActionGroups method instead.
+                TXT);
         }
 
         return $this;

--- a/src/Event/CharacterChangeEvent.php
+++ b/src/Event/CharacterChangeEvent.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Event;
+
+use LotGD2\Entity\Mapped\Character;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CharacterChangeEvent extends Event
+{
+    /**
+     * @param Character $character
+     * @param Character $characterBefore
+     */
+    public function __construct(
+        public readonly Character $character,
+        public readonly Character $characterBefore,
+    ) {
+
+    }
+}

--- a/src/Event/StageChangeEvent.php
+++ b/src/Event/StageChangeEvent.php
@@ -57,6 +57,7 @@ class StageChangeEvent extends Event
     public function setStopRender(bool $stopRender = true): void
     {
         $this->stopRender = $stopRender;
+        $this->stopPropagation();
     }
 
     /**

--- a/src/Form/Race/StandardRaceType.php
+++ b/src/Form/Race/StandardRaceType.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Form\Race;
+
+use LotGD2\Form\GroupedFormType;
+use LotGD2\Game\Race\StandardRace;
+use Symfony\Component\Form\AbstractType;
+
+/**
+ * @phpstan-import-type StandardRaceConfiguration from StandardRace
+ * @extends AbstractType<StandardRaceConfiguration>
+ */
+class StandardRaceType extends AbstractType
+{
+    public function getParent(): string
+    {
+        return GroupedFormType::class;
+    }
+}

--- a/src/Game/Character/DragonCounter.php
+++ b/src/Game/Character/DragonCounter.php
@@ -10,6 +10,7 @@ use LotGD2\Entity\Paragraph;
 use LotGD2\Event\StageChangeEvent;
 use LotGD2\Game\GameTime\NewDay;
 use LotGD2\Game\Random\DiceBagInterface;
+use LotGD2\Game\Stage\ActionService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -33,7 +34,7 @@ class DragonCounter
         #[Autowire(expression: "service('lotgd2.game_loop').getCharacter()")]
         readonly private Character $character,
         readonly private Health $health,
-        readonly private Stats $stats,
+        readonly private Stats $stats, private readonly ActionService $actionService,
     ) {
     }
 
@@ -75,7 +76,7 @@ class DragonCounter
         return $this;
     }
 
-    #[AsEventListener(event: NewDay::PreNewDay, priority: 100)]
+    #[AsEventListener(event: NewDay::OnNewDayBefore, priority: 100)]
     public function onNewDayEvent(StageChangeEvent $event): void
     {
         $character = $event->character;
@@ -87,17 +88,17 @@ class DragonCounter
 
             switch ($event->action->parameters["dk"]) {
                 case "health":
-                    $this->health->addMaxHealth(5);
+                    $this->health->addMaxHealth(5, $character);
                     $success = true;
                     break;
 
                 case "strength":
-                    $this->stats->setAttack($this->stats->getAttack() + 1);
+                    $this->stats->setAttack($this->stats->getAttack() + 1, $character);
                     $success = true;
                     break;
 
                 case "defense":
-                    $this->stats->setDefense($this->stats->getDefense() + 1);
+                    $this->stats->setDefense($this->stats->getDefense() + 1, $character);
                     $success = true;
                     break;
             }
@@ -133,6 +134,8 @@ class DragonCounter
                     ]
                 )
             ];
+
+            $this->actionService->resetActionGroups($stage);
 
             $event->addAction(ActionGroup::EMPTY, new Action(
                 title: "+5 Health",

--- a/src/Game/Character/Equipment.php
+++ b/src/Game/Character/Equipment.php
@@ -22,25 +22,27 @@ readonly class Equipment
     ) {
     }
 
-    public function getItemInSlot(string $slot): ?EquipmentItem
+    public function getItemInSlot(string $slot, ?Character $character = null): ?EquipmentItem
     {
-        $equipment = $this->character->getProperty(self::PropertyName);
+        $character ??= $this->character;
+        $equipment = $character->getProperty(self::PropertyName);
         return $equipment[$slot] ?? null;
     }
 
-    public function setItemInSlot(string $slot, EquipmentItem $item): static
+    public function setItemInSlot(string $slot, EquipmentItem $item, ?Character $character = null): static
     {
-        $this->logger->debug("{$this->character->id}: set new item in slot ($slot): {$item->getName()} ({$item->getStrength()})", [
+        $character ??= $this->character;
+        $this->logger->debug("{$character->id}: set new item in slot ($slot): {$item->getName()} ({$item->getStrength()})", [
             "item" => $item,
         ]);
 
-        $equipment = $this->character->getProperty(self::PropertyName);
+        $equipment = $character->getProperty(self::PropertyName);
         if (is_array($equipment)) {
             $equipment[$slot] = $item;
         } else {
             $equipment = [$slot => $item];
         }
-        $this->character->setProperty(self::PropertyName, $equipment);
+        $character->setProperty(self::PropertyName, $equipment);
         return $this;
     }
 
@@ -53,8 +55,9 @@ readonly class Equipment
         };
     }
 
-    public function getName(string $slot): string
+    public function getName(string $slot, ?Character $character = null): string
     {
-        return $this->getItemInSlot($slot)?->getName() ?? $this->getEmptyName($slot);
+        $character ??= $this->character;
+        return $this->getItemInSlot($slot, $character)?->getName() ?? $this->getEmptyName($slot);
     }
 }

--- a/src/Game/Character/Equipment.php
+++ b/src/Game/Character/Equipment.php
@@ -5,9 +5,12 @@ namespace LotGD2\Game\Character;
 
 use LotGD2\Entity\Character\EquipmentItem;
 use LotGD2\Entity\Mapped\Character;
+use LotGD2\Event\CharacterChangeEvent;
 use LotGD2\Game\GameLoop;
+use LotGD2\Game\Scene\SceneTemplate\DragonTemplate;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
 readonly class Equipment
 {
@@ -59,5 +62,29 @@ readonly class Equipment
     {
         $character ??= $this->character;
         return $this->getItemInSlot($slot, $character)?->getName() ?? $this->getEmptyName($slot);
+    }
+
+    #[AsEventListener(event: DragonTemplate::OnCharacterReset)]
+    public function onCharacterReset(CharacterChangeEvent $event): void
+    {
+        $this->setItemInSlot(
+            slot: Equipment::WeaponSlot,
+            item: new EquipmentItem(
+                name: $this->getEmptyName(Equipment::WeaponSlot),
+                strength: 0,
+                value: 0,
+            ),
+            character: $event->character,
+        );
+
+        $this->setItemInSlot(
+            slot: Equipment::ArmorSlot,
+            item: new EquipmentItem(
+                name: $this->getEmptyName(Equipment::ArmorSlot),
+                strength: 0,
+                value: 0,
+            ),
+            character: $event->character
+        );
     }
 }

--- a/src/Game/Character/Health.php
+++ b/src/Game/Character/Health.php
@@ -5,8 +5,10 @@ namespace LotGD2\Game\Character;
 
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Paragraph;
+use LotGD2\Event\CharacterChangeEvent;
 use LotGD2\Event\StageChangeEvent;
 use LotGD2\Game\GameTime\NewDay;
+use LotGD2\Game\Scene\SceneTemplate\DragonTemplate;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -174,7 +176,7 @@ readonly class Health
         return $this;
     }
 
-    #[AsEventListener(event: NewDay::PostNewDay)]
+    #[AsEventListener(event: NewDay::OnNewDayAfter)]
     public function onNewDayEvent(StageChangeEvent $event): void
     {
         // Increase Age
@@ -214,5 +216,17 @@ readonly class Health
             text: "Your health was restored to {{ maxHealth }}.",
             context: ["maxHealth" => $this->getMaxHealth($event->character)]
         ));
+    }
+
+    #[AsEventListener(event: DragonTemplate::OnCharacterReset)]
+    public function onCharacterReset(CharacterChangeEvent $event): void
+    {
+        $deltaLevel = $event->characterBefore->level - $event->character->level;
+
+        if ($deltaLevel > 0) {
+            $deltaHealth = $deltaLevel * 10;
+            $this->addMaxHealth(-$deltaHealth, $event->character);
+            $this->heal(-$deltaHealth, $event->character);
+        }
     }
 }

--- a/src/Game/Character/Health.php
+++ b/src/Game/Character/Health.php
@@ -144,6 +144,13 @@ readonly class Health
         return $this;
     }
 
+    public function addTurns(int $turns, ?Character $character): self
+    {
+        $character = $character ?? $this->character;
+        $character->setProperty(self::Turns, $this->getTurns($character) + $turns);
+        return $this;
+    }
+
     public function decrementTurns(?Character $character = null): self
     {
         $character = $character ?? $this->character;

--- a/src/Game/Character/Health.php
+++ b/src/Game/Character/Health.php
@@ -9,6 +9,7 @@ use LotGD2\Event\CharacterChangeEvent;
 use LotGD2\Event\StageChangeEvent;
 use LotGD2\Game\GameTime\NewDay;
 use LotGD2\Game\Scene\SceneTemplate\DragonTemplate;
+use LotGD2\Game\Scene\SceneTemplate\TrainingTemplate;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -216,6 +217,17 @@ readonly class Health
             text: "Your health was restored to {{ maxHealth }}.",
             context: ["maxHealth" => $this->getMaxHealth($event->character)]
         ));
+    }
+
+    #[AsEventListener(event: TrainingTemplate::OnCharacterLevelUp, priority: -100)]
+    public function onCharacterLevelIncrease(CharacterChangeEvent $event): void
+    {
+        $deltaLevel = $event->character->level - $event->characterBefore->level;
+
+        if ($deltaLevel > 0) {
+            $this->addMaxHealth($deltaLevel * 10, $event->character);
+            $this->heal(null, $event->character);
+        }
     }
 
     #[AsEventListener(event: DragonTemplate::OnCharacterReset)]

--- a/src/Game/Character/Race.php
+++ b/src/Game/Character/Race.php
@@ -9,9 +9,11 @@ use LotGD2\Entity\ActionGroup;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Mapped\Race as RaceEntity;
 use LotGD2\Entity\Paragraph;
+use LotGD2\Event\CharacterChangeEvent;
 use LotGD2\Event\StageChangeEvent;
 use LotGD2\Game\GameTime\NewDay;
 use LotGD2\Game\Race\RaceInterface;
+use LotGD2\Game\Scene\SceneTemplate\DragonTemplate;
 use LotGD2\Kernel;
 use LotGD2\Repository\RaceRepository;
 use Psr\Log\LoggerInterface;
@@ -45,7 +47,7 @@ class Race
         $this->container = $this->kernel?->getContainer();
     }
 
-    #[AsEventListener(event: NewDay::PreNewDay, priority: 90)]
+    #[AsEventListener(event: NewDay::OnNewDayBefore, priority: 90)]
     public function onNewDayEvent(StageChangeEvent $event): void
     {
         $this->stopWatch->start("lotgd2.Race.onNewDay", "lotgd");
@@ -94,6 +96,7 @@ class Race
         ));
 
         $this->setRace($event->character, $race);
+        $event->addAction(ActionGroup::EMPTY, new Action(title: "Continue"));
 
         return true;
     }
@@ -163,7 +166,13 @@ class Race
      */
     public function hasRace(Character $character): bool
     {
-        return $this->getRaceProperty($character) !== null;
+        $raceProperty = $this->getRaceProperty($character);
+
+        if ($raceProperty === null || count($raceProperty) === 0 || $this->getRace($character) === null) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -173,7 +182,7 @@ class Race
     public function getRace(Character $character): ?RaceEntity
     {
         $race = $this->getRaceProperty($character);
-        return $race === null ? null : $this->raceRepository->find($race["id"]);
+        return $race === null ? null : (isset($race["id"]) ? $this->raceRepository->find($race["id"]) : null);
     }
 
     /**
@@ -183,17 +192,17 @@ class Race
     public function getRaceName(Character $character): ?string
     {
         $race = $this->getRaceProperty($character);
-        return $race === null ? null : $race["name"];
+        return $race === null ? null : ($race["name"] ?? "");
     }
 
     /**
      * @param Character $character
-     * @return string|null
+     * @return class-string<RaceInterface>|string|null
      */
     public function getRaceClass(Character $character): ?string
     {
         $race = $this->getRaceProperty($character);
-        return $race === null ? null : $race["className"];
+        return $race === null ? null : ($race["className"] ?? null);
     }
 
     /**
@@ -203,16 +212,22 @@ class Race
     public function getRaceConfiguration(Character $character): ?array
     {
         $race = $this->getRaceProperty($character);
-        return $race === null ? null : $race["configuration"];
+        return $race === null ? null : ($race["configuration"] ?? []);
     }
 
     /**
      * @param Character $character
-     * @param RaceEntity<array<string, mixed>> $race
+     * @param RaceEntity<array<string, mixed>>|null $race
      * @return void
      */
-    public function setRace(Character $character, RaceEntity $race): void
+    public function setRace(Character $character, ?RaceEntity $race): void
     {
+        if ($race === null) {
+            $character->setProperty("race", []);
+            // No race set - remove everything, and then return.
+            return;
+        }
+
         $character->setProperty("race", [
             "id" => $race->id,
             "name" => $race->name,
@@ -238,5 +253,24 @@ class Race
             // If the class does not exist, we log this as a critical error.
             $this->logger->critical("There was an issue with the race class {$race->className}. {$e->getMessage()}", context: ["exception" => $e]);
         }
+    }
+
+    #[AsEventListener(event: DragonTemplate::OnCharacterReset)]
+    public function onCharacterReset(CharacterChangeEvent $event): void
+    {
+        $race = $this->getRace($event->character);
+        $raceConfig = $this->getRaceConfiguration($event->character);
+        $className = $this->getRaceClass($event->character);
+
+        if ($className === null or !class_exists($className)) {
+            // @phpstan-ignore encapsedStringPart.nonString
+            $this->logger->critical("{$event->character}: The race class {$className} does not exist, rollback of configuration is not possible");
+        } else {
+            /** @var RaceInterface $raceClass */
+            $raceClass = $this->container->get($className);
+            $raceClass->onDeselect($event->character, $race, $raceConfig);
+        }
+
+        $this->setRace($event->character, null);
     }
 }

--- a/src/Game/Character/Race.php
+++ b/src/Game/Character/Race.php
@@ -263,7 +263,6 @@ class Race
         $className = $this->getRaceClass($event->character);
 
         if ($className === null or !class_exists($className)) {
-            // @phpstan-ignore encapsedStringPart.nonString
             $this->logger->critical("{$event->character}: The race class {$className} does not exist, rollback of configuration is not possible");
         } else {
             /** @var RaceInterface $raceClass */

--- a/src/Game/Character/Race.php
+++ b/src/Game/Character/Race.php
@@ -1,0 +1,242 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Game\Character;
+
+use Exception;
+use LotGD2\Entity\Action;
+use LotGD2\Entity\ActionGroup;
+use LotGD2\Entity\Mapped\Character;
+use LotGD2\Entity\Mapped\Race as RaceEntity;
+use LotGD2\Entity\Paragraph;
+use LotGD2\Event\StageChangeEvent;
+use LotGD2\Game\GameTime\NewDay;
+use LotGD2\Game\Race\RaceInterface;
+use LotGD2\Kernel;
+use LotGD2\Repository\RaceRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Stopwatch\Stopwatch;
+use UnexpectedValueException;
+
+/**
+ * @phpstan-type  RacePropertyShape array{
+ *     id: int,
+ *     name: string,
+ *     className: class-string,
+ *     configuration: array<string, mixed>,
+ * }
+ */
+class Race
+{
+    private ?ContainerInterface $container;
+
+    const string RaceProperty = "race";
+
+    public function __construct(
+        private readonly ?Kernel $kernel,
+        private readonly ?LoggerInterface $logger,
+        private readonly ?Stopwatch $stopWatch,
+        private readonly RaceRepository $raceRepository,
+    ) {
+        $this->container = $this->kernel?->getContainer();
+    }
+
+    #[AsEventListener(event: NewDay::PreNewDay, priority: 90)]
+    public function onNewDayEvent(StageChangeEvent $event): void
+    {
+        $this->stopWatch->start("lotgd2.Race.onNewDay", "lotgd");
+
+        $character = $event->character;
+        $stop = false;
+
+        if (isset($event->action->parameters["race"])) {
+            $stop = $this->doRaceSelection($event);
+        }
+
+        if ($this->hasRace($character) === false) {
+            $stop = $this->showRaceSelection($event);
+        }
+
+        if ($stop) {
+            $event->setStopRender();
+        }
+
+        $this->stopWatch->stop("lotgd2.Race.onNewDay");
+    }
+
+    /**
+     * Selects the race and sets the character's property to it.
+     *
+     * If the race 'disappears' between selections, it will return false and the race selection screen is displayed
+     *  again.
+     * @param StageChangeEvent $event
+     * @return bool
+     */
+    public function doRaceSelection(StageChangeEvent $event): bool
+    {
+        $raceId = $event->action->parameters["race"];
+        $race = $this->raceRepository->find($raceId);
+
+        if ($race instanceof RaceEntity === false) {
+            // Race disappeared, or the selection was faulty, let continue to the character screen
+            return false;
+        }
+
+        $event->stage->title = "Where to you recall growing up?";
+        $event->stage->clearParagraphs();
+        $event->stage->addParagraph(new Paragraph(
+            id: "lotdg2.paragraph.Race.onRaceSelection",
+            text: $race->selectionText,
+        ));
+
+        $this->setRace($event->character, $race);
+
+        return true;
+    }
+
+    /**
+     * Adds all races with a short description to the stage's description and adds for each one an action to let the
+     *  character choose.
+     *
+     * If there are no races available, the event will be skipped.
+     * @param StageChangeEvent $event
+     * @return bool
+     */
+    public function showRaceSelection(StageChangeEvent $event): bool
+    {
+        $races = $this->raceRepository->findAll();
+
+        if (count($races) === 0) {
+            // If there is no race to choose from, continue and skip this event
+            $this->logger->info("There are no races available. Skipping race selection.");
+            return false;
+        }
+
+        $event->stage->clear();
+        $event->stage->title = "Where to you recall growing up?";
+        $event->stage->addParagraph(new Paragraph(
+            id: "lotdg2.paragraph.Race.generic",
+            text: "From where are you?")
+        );
+
+        $actionGroup = new ActionGroup(
+            id: "lotgd2.actionGroup.Race",
+            title: "Pick one",
+        );
+
+        $event->stage->addActionGroup($actionGroup);
+
+        foreach ($races as $race) {
+            $event->stage->addParagraph(new Paragraph(
+                id: "lotgd2.paragraph.Race.entry{$race->id}",
+                text: $race->description
+            ));
+
+            $event->addAction($actionGroup, new Action(
+                title: $race->name,
+                parameters: [
+                    "race" => $race->id,
+                ],
+                reference: "lotgd2.action.Race.entry{$race->id}"
+            ));
+        }
+
+        return true;
+    }
+
+    /**
+     * @param Character $character
+     * @return null|RacePropertyShape
+     */
+    public function getRaceProperty(Character $character): null|array
+    {
+        return $character->getProperty("race");
+    }
+
+    /**
+     * @param Character $character
+     * @return bool
+     */
+    public function hasRace(Character $character): bool
+    {
+        return $this->getRaceProperty($character) !== null;
+    }
+
+    /**
+     * @param Character $character
+     * @return RaceEntity<array<string, mixed>>|null
+     */
+    public function getRace(Character $character): ?RaceEntity
+    {
+        $race = $this->getRaceProperty($character);
+        return $race === null ? null : $this->raceRepository->find($race["id"]);
+    }
+
+    /**
+     * @param Character $character
+     * @return string|null
+     */
+    public function getRaceName(Character $character): ?string
+    {
+        $race = $this->getRaceProperty($character);
+        return $race === null ? null : $race["name"];
+    }
+
+    /**
+     * @param Character $character
+     * @return string|null
+     */
+    public function getRaceClass(Character $character): ?string
+    {
+        $race = $this->getRaceProperty($character);
+        return $race === null ? null : $race["className"];
+    }
+
+    /**
+     * @param Character $character
+     * @return null|array<string, mixed>
+     */
+    public function getRaceConfiguration(Character $character): ?array
+    {
+        $race = $this->getRaceProperty($character);
+        return $race === null ? null : $race["configuration"];
+    }
+
+    /**
+     * @param Character $character
+     * @param RaceEntity<array<string, mixed>> $race
+     * @return void
+     */
+    public function setRace(Character $character, RaceEntity $race): void
+    {
+        $character->setProperty("race", [
+            "id" => $race->id,
+            "name" => $race->name,
+            "className" => $race->className,
+            "configuration" => $race->configuration,
+        ]);
+
+        if ($race->className === null) {
+            // No class - no hook.
+            return;
+        }
+
+        if (!class_exists($race->className)) {
+            // If the class does not exist, we log this as a critical error.
+            $this->logger->critical("The race class {$race->className} does not exist.");
+            return;
+        }
+
+        try {
+            $raceClass = $this->container->get($race->className);
+            $raceClass->onSelect($character, $race);
+        } catch (Exception $e) {
+            // If the class does not exist, we log this as a critical error.
+            $this->logger->critical("There was an issue with the race class {$race->className}. {$e->getMessage()}", context: ["exception" => $e]);
+        }
+    }
+}

--- a/src/Game/Character/Stats.php
+++ b/src/Game/Character/Stats.php
@@ -23,25 +23,28 @@ readonly class Stats
     ) {
     }
 
-    public function getExperience(): int
+    public function getExperience(?Character $character = null): int
     {
-        return $this->character->getProperty(self::ExperiencePropertyName, 0);
+        $character ??= $this->character;
+        return $character->getProperty(self::ExperiencePropertyName, 0);
     }
 
-    public function setExperience(int $experience): static
+    public function setExperience(int $experience, ?Character $character = null): static
     {
-        $this->logger->debug("{$this->character->id}: set experience to {$experience}");
-        $this->character->setProperty(self::ExperiencePropertyName, $experience);
+        $character ??= $this->character;
+        $this->logger->debug("{$character->id}: set experience to {$experience}");
+        $character->setProperty(self::ExperiencePropertyName, $experience);
         return $this;
     }
 
-    public function addExperience(int $experience): static
+    public function addExperience(int $experience, ?Character $character = null): static
     {
-        $this->setExperience($this->getExperience() + $experience);
+        $character ??= $this->character;
+        $this->setExperience($this->getExperience() + $experience, $character);
         return $this;
     }
 
-    public function getRequiredExperience(): ?int
+    public function getRequiredExperience(?Character $character = null): ?int
     {
         $requiredExperience = [
             100,
@@ -61,69 +64,80 @@ readonly class Stats
             43930,
         ];
 
-        return $requiredExperience[$this->character->level - 1] ?? null;
+        $character ??= $this->character;
+        return $requiredExperience[$character->level - 1] ?? null;
     }
 
-    public function getLevel(): int
+    public function getLevel(?Character $character = null): int
     {
-        return $this->character->level;
+        $character ??= $this->character;
+        return $character->level;
     }
 
-    public function getAttack(): int
+    public function getAttack(?Character $character = null): int
     {
-        return $this->character->getProperty(self::AttackPropertyName, 1);
+        $character ??= $this->character;
+        return $character->getProperty(self::AttackPropertyName, 1);
     }
 
-    public function getTotalAttack(): int
+    public function getTotalAttack(?Character $character = null): int
     {
-        return $this->getAttack() + ($this->equipment->getItemInSlot(Equipment::WeaponSlot)?->getStrength() ?? 0);
+        $character ??= $this->character;
+        return $this->getAttack($character) + ($this->equipment->getItemInSlot(Equipment::WeaponSlot, $character)?->getStrength() ?? 0);
     }
 
-    public function setAttack(int $attack): static
+    public function setAttack(int $attack, ?Character $character = null): static
     {
-        $this->logger?->debug("{$this->character->id}: attack set to {$attack} (was {$this->getAttack()}) before).");
-        $this->character->setProperty(self::AttackPropertyName, $attack);
+        $character ??= $this->character;
+        $this->logger?->debug("{$character->id}: attack set to {$attack} (was {$this->getAttack($character)}) before).");
+        $character->setProperty(self::AttackPropertyName, $attack);
         return $this;
     }
 
-    public function addAttack(int $attack): static
+    public function addAttack(int $attack, ?Character $character = null): static
     {
-        $this->setAttack($this->getAttack() + $attack);
+        $character ??= $this->character;
+        $this->setAttack($this->getAttack($character) + $attack, $character);
         return $this;
     }
 
-    public function getDefense(): int
+    public function getDefense(?Character $character = null): int
     {
-        return $this->character->getProperty(self::DefensePropertyName, 1);
+        $character ??= $this->character;
+        return $character->getProperty(self::DefensePropertyName, 1);
     }
 
-    public function setDefense(int $defense): static
+    public function setDefense(int $defense, ?Character $character = null): static
     {
-        $this->logger?->debug("{$this->character->id}: defense set to {$defense} (was {$this->getDefense()}) before).");
-        $this->character->setProperty(self::DefensePropertyName, $defense);
+        $character ??= $this->character;
+        $this->logger?->debug("{$character->id}: defense set to {$defense} (was {$this->getDefense($character)}) before).");
+        $character->setProperty(self::DefensePropertyName, $defense);
         return $this;
     }
 
-    public function addDefense(int $defense): static
+    public function addDefense(int $defense, ?Character $character = null): static
     {
-        $this->setDefense($this->getDefense() + $defense);
+        $character ??= $this->character;
+        $this->setDefense($this->getDefense() + $defense, $character);
         return $this;
     }
 
-    public function getTotalDefense(): int
+    public function getTotalDefense(?Character $character = null): int
     {
-        return $this->getDefense() + ($this->equipment->getItemInSlot(Equipment::ArmorSlot)?->getStrength() ?? 0);
+        $character ??= $this->character;
+        return $this->getDefense($character) + ($this->equipment->getItemInSlot(Equipment::ArmorSlot, $character)?->getStrength() ?? 0);
     }
 
-    public function levelUp(): static
+    public function levelUp(?Character $character = null): static
     {
-        $this->character->level = $this->character->level + 1;
+        $character ??= $this->character;
+        $character->level = $character->level + 1;
 
-        $this->logger?->debug("{$this->character->id}: Level increased to {$this->character->level}.");
+        $this->logger?->debug("{$character->id}: Level increased to {$character->level}.");
 
-        $this->addAttack(1);
-        $this->addDefense(1);
-        $this->health->addMaxHealth(10);
+        $this->addAttack(1, $character);
+        $this->addDefense(1, $character);
+        $this->health->addMaxHealth(10, $character);
 
         return $this;
     }

--- a/src/Game/Character/Stats.php
+++ b/src/Game/Character/Stats.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 namespace LotGD2\Game\Character;
 
 use LotGD2\Entity\Mapped\Character;
+use LotGD2\Event\CharacterChangeEvent;
+use LotGD2\Game\Scene\SceneTemplate\DragonTemplate;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
 readonly class Stats
 {
@@ -140,5 +143,19 @@ readonly class Stats
         $this->health->addMaxHealth(10, $character);
 
         return $this;
+    }
+
+    #[AsEventListener(event: DragonTemplate::OnCharacterReset)]
+    public function onCharacterReset(CharacterChangeEvent $event): void
+    {
+        $deltaLevel = $event->characterBefore->level - $event->character->level;
+
+        if ($deltaLevel > 0) {
+            $deltaIncrease = $deltaLevel;
+            $this->addAttack(-$deltaIncrease, $event->character);
+            $this->addDefense(-$deltaIncrease, $event->character);
+        }
+
+        $this->setExperience(0, $event->character);
     }
 }

--- a/src/Game/Character/Stats.php
+++ b/src/Game/Character/Stats.php
@@ -6,6 +6,7 @@ namespace LotGD2\Game\Character;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Event\CharacterChangeEvent;
 use LotGD2\Game\Scene\SceneTemplate\DragonTemplate;
+use LotGD2\Game\Scene\SceneTemplate\TrainingTemplate;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -20,7 +21,6 @@ readonly class Stats
     public function __construct(
         private ?LoggerInterface $logger,
         private Equipment $equipment,
-        private Health $health,
         #[Autowire(expression: "service('lotgd2.game_loop').getCharacter()")]
         private Character $character,
     ) {
@@ -131,18 +131,14 @@ readonly class Stats
         return $this->getDefense($character) + ($this->equipment->getItemInSlot(Equipment::ArmorSlot, $character)?->getStrength() ?? 0);
     }
 
-    public function levelUp(?Character $character = null): static
+    #[AsEventListener(event: TrainingTemplate::OnCharacterLevelUp)]
+    public function onCharacterLevelIncrease(CharacterChangeEvent $event): void
     {
-        $character ??= $this->character;
-        $character->level = $character->level + 1;
+        $deltaLevel = $event->character->level - $event->characterBefore->level;
+        dump($deltaLevel);
 
-        $this->logger?->debug("{$character->id}: Level increased to {$character->level}.");
-
-        $this->addAttack(1, $character);
-        $this->addDefense(1, $character);
-        $this->health->addMaxHealth(10, $character);
-
-        return $this;
+        $this->addAttack(1*$deltaLevel, $event->character);
+        $this->addDefense(1*$deltaLevel, $event->character);
     }
 
     #[AsEventListener(event: DragonTemplate::OnCharacterReset)]

--- a/src/Game/GameLoop.php
+++ b/src/Game/GameLoop.php
@@ -48,7 +48,7 @@ class GameLoop
         return $this->character;
     }
 
-    public function setCharacter(Character $character): self
+    public function setCharacter(?Character $character): self
     {
         $this->character = $character;
         return $this;

--- a/src/Game/GameTime/NewDay.php
+++ b/src/Game/GameTime/NewDay.php
@@ -18,8 +18,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class NewDay
 {
     const string LastNewDayProperty = "lotgd2.internal.lastNewDay";
-    const string PreNewDay = "lotgd2.event.preNewDay";
-    const string PostNewDay = "lotgd2.event.postNewDay";
+    const string OnNewDayBefore = "lotgd2.NewDay.event.before";
+    const string OnNewDayAfter = "lotgd2.NewDay.event.after";
 
     public function __construct(
         private readonly LoggerInterface $logger,
@@ -79,26 +79,32 @@ class NewDay
         $this->actionService->resetActionGroups($stage);
 
         $event = new StageChangeEvent($stage, $action, $scene);
-        $this->eventDispatcher->dispatch($event, self::PreNewDay);
+        $this->eventDispatcher->dispatch($event, self::OnNewDayBefore);
 
         if ($event->stopRender) {
+            $this->logger->debug("NewDay: Render was stopped by OnNewDayBefore event.");
             return;
         }
 
-        // We do not add actions or set the current last day if the eventDispatcher was stopped.
+        // We do not set the current last day or add navigation if the eventDispatcher was stopped.
 
         // Connect to the originally targeted Scene
+        $this->addContinueAction($stage, $scene, $action);
+
+        // Set the last new day to the current day.
+        $this->setLastNewDay($character);
+
+        $event = new StageChangeEvent($stage, $action, $scene);
+        $this->eventDispatcher->dispatch($event, self::OnNewDayAfter);
+    }
+
+    private function addContinueAction(Stage $stage, Scene $scene, Action $action): void
+    {
         $stage->addAction(ActionGroup::EMPTY, new Action(
             scene: $scene,
             title: "Continue",
             parameters: $action->parameters,
             reference: $action->reference,
         ));
-
-        // Set last new day to the current day.
-        $this->setLastNewDay($character);
-
-        $event = new StageChangeEvent($stage, $action, $scene);
-        $this->eventDispatcher->dispatch($event, self::PostNewDay);
     }
 }

--- a/src/Game/Race/RaceInterface.php
+++ b/src/Game/Race/RaceInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Game\Race;
+
+use LotGD2\Entity\Mapped\Character;
+use LotGD2\Entity\Mapped\Race;
+
+/**
+ * @template TConfig of array<string, mixed> = array<string, mixed>
+ */
+interface RaceInterface
+{
+    /**
+     * @param Character $character
+     * @param Race<covariant TConfig> $race
+     * @return void
+     */
+    public function onSelect(Character $character, Race $race): void;
+
+    /**
+     * @param Character $character
+     * @param Race<covariant TConfig> $race
+     * @param TConfig $oldConfiguration
+     * @return void
+     */
+    public function onDeselect(Character $character, Race $race, array $oldConfiguration): void;
+}

--- a/src/Game/Race/StandardRace.php
+++ b/src/Game/Race/StandardRace.php
@@ -44,19 +44,19 @@ class StandardRace implements RaceInterface
     {
         $loggerContext = ["what" => "select", "race" => $race];
 
-        if ($race->configuration["attack"] <> 0) {
+        if (isset($race->configuration["attack"]) and $race->configuration["attack"] <> 0) {
             $value = $race->configuration["attack"];
             $this->logger->debug("Character $character->id: Increase attack by $value for race {$race->name}.", $loggerContext);
             $this->stats->addAttack($value, $character);
         }
 
-        if ($race->configuration["defense"] <> 0) {
+        if (isset($race->configuration["defense"]) and $race->configuration["defense"] <> 0) {
             $value = $race->configuration["defense"];
             $this->logger->debug("Character $character->id: Increase defense by $value for race {$race->name}.", $loggerContext);
             $this->stats->addDefense($value, $character);
         }
 
-        if ($race->configuration["health"] <> 0) {
+        if (isset($race->configuration["health"]) && $race->configuration["health"] <> 0) {
             $value = $race->configuration["health"];
             $this->logger->debug("Character $character->id: Increase health by $value for race {$race->name}.", $loggerContext);
             $this->health->addMaxHealth($value, $character);
@@ -67,26 +67,26 @@ class StandardRace implements RaceInterface
     {
         $loggerContext = ["what" => "unselect", "race" => $race, "oldConfiguration" => $oldConfiguration];
 
-        if ($oldConfiguration["attack"] <> 0) {
-            $value = $race->configuration["attack"];
+        if (isset($oldConfiguration["attack"]) && $oldConfiguration["attack"] <> 0) {
+            $value = $oldConfiguration["attack"];
             $this->logger->debug("Character $character->id: Decrease attack by $value for race {$race->name}.", $loggerContext);
             $this->stats->addAttack(-$value, $character);
         }
 
-        if ($race->configuration["defense"] <> 0) {
-            $value = $race->configuration["defense"];
+        if (isset($oldConfiguration["defense"]) && $oldConfiguration["defense"] <> 0) {
+            $value = $oldConfiguration["defense"];
             $this->logger->debug("Character $character->id: Decrease defense by $value for race {$race->name}.", $loggerContext);
             $this->stats->addDefense(-$value, $character);
         }
 
-        if ($race->configuration["health"] <> 0) {
-            $value = $race->configuration["health"];
+        if (isset($oldConfiguration["health"]) && $oldConfiguration["health"] <> 0) {
+            $value = $oldConfiguration["health"];
             $this->logger->debug("Character $character->id: Increase health by $value for race {$race->name}.", $loggerContext);
             $this->health->addMaxHealth(-$value, $character);
         }
     }
 
-    #[AsEventListener(event: NewDay::PostNewDay)]
+    #[AsEventListener(event: NewDay::OnNewDayAfter)]
     public function onNewDayEvent(StageChangeEvent $event): void
     {
         $character = $event->character;

--- a/src/Game/Race/StandardRace.php
+++ b/src/Game/Race/StandardRace.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Game\Race;
+
+use LotGD2\Attribute\TemplateType;
+use LotGD2\Entity\Mapped\Character;
+use LotGD2\Entity\Mapped\Race;
+use LotGD2\Entity\Paragraph;
+use LotGD2\Event\StageChangeEvent;
+use LotGD2\Form\Race\StandardRaceType;
+use LotGD2\Game\Character\Health;
+use LotGD2\Game\Character\Race as RaceHandler;
+use LotGD2\Game\Character\Stats;
+use LotGD2\Game\GameTime\NewDay;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * @phpstan-type StandardRaceConfiguration array{
+ *     attack?: int,
+ *     defense?: int,
+ *     turns?: int,
+ *     health?: int,
+ *     goldFactor?: float,
+ *     experienceFactor?: float,
+ * }
+ * @implements RaceInterface<StandardRaceConfiguration>
+ */
+#[Autoconfigure(public: true)]
+#[TemplateType(StandardRaceType::class)]
+class StandardRace implements RaceInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private Stats $stats,
+        private Health $health,
+        private RaceHandler $race,
+    ) {
+    }
+
+    public function onSelect(Character $character, Race $race): void
+    {
+        $loggerContext = ["what" => "select", "race" => $race];
+
+        if ($race->configuration["attack"] <> 0) {
+            $value = $race->configuration["attack"];
+            $this->logger->debug("Character $character->id: Increase attack by $value for race {$race->name}.", $loggerContext);
+            $this->stats->addAttack($value, $character);
+        }
+
+        if ($race->configuration["defense"] <> 0) {
+            $value = $race->configuration["defense"];
+            $this->logger->debug("Character $character->id: Increase defense by $value for race {$race->name}.", $loggerContext);
+            $this->stats->addDefense($value, $character);
+        }
+
+        if ($race->configuration["health"] <> 0) {
+            $value = $race->configuration["health"];
+            $this->logger->debug("Character $character->id: Increase health by $value for race {$race->name}.", $loggerContext);
+            $this->health->addMaxHealth($value, $character);
+        }
+    }
+
+    public function onDeselect(Character $character, Race $race, array $oldConfiguration): void
+    {
+        $loggerContext = ["what" => "unselect", "race" => $race, "oldConfiguration" => $oldConfiguration];
+
+        if ($oldConfiguration["attack"] <> 0) {
+            $value = $race->configuration["attack"];
+            $this->logger->debug("Character $character->id: Decrease attack by $value for race {$race->name}.", $loggerContext);
+            $this->stats->addAttack(-$value, $character);
+        }
+
+        if ($race->configuration["defense"] <> 0) {
+            $value = $race->configuration["defense"];
+            $this->logger->debug("Character $character->id: Decrease defense by $value for race {$race->name}.", $loggerContext);
+            $this->stats->addDefense(-$value, $character);
+        }
+
+        if ($race->configuration["health"] <> 0) {
+            $value = $race->configuration["health"];
+            $this->logger->debug("Character $character->id: Increase health by $value for race {$race->name}.", $loggerContext);
+            $this->health->addMaxHealth(-$value, $character);
+        }
+    }
+
+    #[AsEventListener(event: NewDay::PostNewDay)]
+    public function onNewDayEvent(StageChangeEvent $event): void
+    {
+        $character = $event->character;
+        if ($this->race->hasRace($character) and $this->race->getRaceClass($character) === self::class) {
+            $race = $this->race->getRace($character);
+
+            if ($race === null) {
+                $this->logger->critical("Race disappeared");
+                return;
+            }
+
+            $value = $race->configuration["turns"] ?? 0;
+            $loggerContext = ["what" => "turn", "race" => $race];
+
+            if ($value === 0) {
+                return;
+            }
+
+            $this->health->addTurns($value, $character);
+            $this->logger->debug("Character $character->id: Increase health by $value for race {$race->name}.", $loggerContext);
+            $event->stage->addParagraph(new Paragraph(
+                "lotgd2.paragraph.StandardRace.onNewDay",
+                text: <<<TXT
+                    Because of your race, everything is easier for you.
+                    You get {{ value }} extra {% if value == 1 %}turn{%else%}turns{%endif%}
+                    TXT,
+                context: ["value" => $value],
+            ));
+        }
+    }
+}

--- a/src/Game/Race/StandardRace.php
+++ b/src/Game/Race/StandardRace.php
@@ -106,7 +106,7 @@ class StandardRace implements RaceInterface
             }
 
             $this->health->addTurns($value, $character);
-            $this->logger->debug("Character $character->id: Increase health by $value for race {$race->name}.", $loggerContext);
+            $this->logger->debug("Character $character->id: Increase turns by $value for race {$race->name}.", $loggerContext);
             $event->stage->addParagraph(new Paragraph(
                 "lotgd2.paragraph.StandardRace.onNewDay",
                 text: <<<TXT

--- a/src/Game/Scene/SceneRenderer.php
+++ b/src/Game/Scene/SceneRenderer.php
@@ -144,7 +144,7 @@ readonly class SceneRenderer
             $this->logger,
             $character,
             health: $health,
-            stats: new Stats($this->logger, $equipment, $health, $character),
+            stats: new Stats($this->logger, $equipment, $character),
             gold: new Gold($this->logger, $character),
             equipment: $equipment,
         );

--- a/src/Game/Scene/SceneTemplate/BankTemplate.php
+++ b/src/Game/Scene/SceneTemplate/BankTemplate.php
@@ -194,7 +194,7 @@ class BankTemplate implements SceneTemplateInterface
         $this->setGoldInBank($character, $templateConfig, $this->getGoldInBank($character, $templateConfig) + $amount);
     }
 
-    #[AsEventListener(event: NewDay::PostNewDay)]
+    #[AsEventListener(event: NewDay::OnNewDayAfter)]
     public function onNewDayEvent(StageChangeEvent $event): void
     {
         $this->stopwatch->start("lotgd2.BankTemplate.onNewDayEvent");

--- a/src/Game/Scene/SceneTemplate/DragonTemplate.php
+++ b/src/Game/Scene/SceneTemplate/DragonTemplate.php
@@ -25,6 +25,7 @@ use LotGD2\Game\Random\DiceBagInterface;
 use LotGD2\Game\Scene\SceneAttachment\BattleAttachment;
 use LotGD2\Repository\AttachmentRepository;
 use LotGD2\Repository\SceneRepository;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -49,6 +50,7 @@ class DragonTemplate implements SceneTemplateInterface
 
     public function __construct(
         readonly private LoggerInterface $logger,
+        readonly private EventDispatcherInterface $eventDispatcher,
         readonly private DiceBagInterface $diceBag,
         readonly private AttachmentRepository $attachmentRepository,
         readonly private SceneRepository $sceneRepository,
@@ -213,5 +215,6 @@ class DragonTemplate implements SceneTemplateInterface
         ));
 
         // Later, offer the possibility to change this behaviour by raising events.
+        //$this->eventDispatcher->dispatch();
     }
 }

--- a/src/Game/Scene/SceneTemplate/DragonTemplate.php
+++ b/src/Game/Scene/SceneTemplate/DragonTemplate.php
@@ -45,7 +45,7 @@ class DragonTemplate implements SceneTemplateInterface
     use DefaultSceneTemplate;
     use DefaultFightTrait;
 
-    const string OnCharacterReset = 'lotgd2.DragonTemplate.event.characterReset';
+    const string OnCharacterReset = 'lotgd2.event.DragonTemplate.characterReset';
 
     public function __construct(
         readonly private LoggerInterface $logger,

--- a/src/Game/Scene/SceneTemplate/DragonTemplate.php
+++ b/src/Game/Scene/SceneTemplate/DragonTemplate.php
@@ -9,26 +9,23 @@ use LotGD2\Entity\ActionGroup;
 use LotGD2\Entity\Battle\BattleState;
 use LotGD2\Entity\Battle\Fighter;
 use LotGD2\Entity\Character\EquipmentItem;
-use LotGD2\Entity\Mapped\Character;
-use LotGD2\Entity\Mapped\Scene;
-use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Entity\Paragraph;
+use LotGD2\Event\CharacterChangeEvent;
 use LotGD2\Form\Scene\SceneTemplate\DragonTemplateType;
 use LotGD2\Game\Battle\Battle;
 use LotGD2\Game\Character\DragonCounter;
 use LotGD2\Game\Character\Equipment;
 use LotGD2\Game\Character\Gold;
-use LotGD2\Game\Character\Health;
 use LotGD2\Game\Character\Stats;
 use LotGD2\Game\GameTime\NewDay;
 use LotGD2\Game\Random\DiceBagInterface;
 use LotGD2\Game\Scene\SceneAttachment\BattleAttachment;
+use LotGD2\Game\Stage\ActionService;
 use LotGD2\Repository\AttachmentRepository;
 use LotGD2\Repository\SceneRepository;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @phpstan-type DragonTemplateConfiguration array{
@@ -48,6 +45,8 @@ class DragonTemplate implements SceneTemplateInterface
     use DefaultSceneTemplate;
     use DefaultFightTrait;
 
+    const string OnCharacterReset = 'lotgd2.DragonTemplate.event.characterReset';
+
     public function __construct(
         readonly private LoggerInterface $logger,
         readonly private EventDispatcherInterface $eventDispatcher,
@@ -56,11 +55,10 @@ class DragonTemplate implements SceneTemplateInterface
         readonly private SceneRepository $sceneRepository,
         readonly private Battle $battle,
         readonly private NewDay $newDay,
-        readonly private Health $health,
         readonly private Gold $gold,
         readonly private Stats $stats,
-        readonly private Equipment $equipment,
         readonly private DragonCounter $dragonCounter,
+        private readonly ActionService $actionService,
     ) {
 
     }
@@ -113,9 +111,9 @@ class DragonTemplate implements SceneTemplateInterface
             name: $this->scene->templateConfig["dragonName"] ?? "The Green Dragon",
             level: 18,
             weapon: $this->scene->templateConfig["dragonWeapon"] ?? "Great Flaming Maw",
-            health: 160, # 300
-            attack: 35, #45,
-            defense: 20, #25,
+            health: 150, # 300
+            attack: 31, #45,
+            defense: 15, #25,
         );
 
         $battleState = $this->battle->start($dragon, allowFlee: false);
@@ -139,15 +137,13 @@ class DragonTemplate implements SceneTemplateInterface
 
     public function onFightWon(BattleState $battleState): void
     {
-        $this->stats->levelUp();
-        $this->health->heal();
-
         $description = <<<TEXT
             With a mighty final blow, {{ badGuy.name }} lets out a tremendous bellow and falls at your feet, dead at last.
             TEXT;
 
         $this->logger->debug("{$this->character->id}: Victory over the Dragon.");
 
+        $this->actionService->resetActionGroups($this->stage);
         $this->stage->addAction(
             ActionGroup::EMPTY,
             new Action(
@@ -158,6 +154,8 @@ class DragonTemplate implements SceneTemplateInterface
                 ]
             )
         );
+
+        dump($this->stage);
 
         $this->stage->paragraphs = [
             new Paragraph(
@@ -172,7 +170,7 @@ class DragonTemplate implements SceneTemplateInterface
 
     public function epilogueAction(): void
     {
-        $this->stage->clearActionGroups();
+        $this->actionService->resetActionGroups($this->stage);
         $this->stage->title = "Victory!";
         $description = $this->scene->templateConfig["text"]["epilogue"];
         $this->stage->addAction(ActionGroup::EMPTY, new Action(
@@ -197,24 +195,13 @@ class DragonTemplate implements SceneTemplateInterface
 
     public function resetCharacter(): void
     {
-        $this->character->level = 1;
-        $this->health->setMaxHealth(10);
-        $this->health->setHealth(10);
-        $this->stats->setExperience(0);
-        $this->stats->setAttack(1);
-        $this->stats->setDefense(1);
-        $this->equipment->setItemInSlot(Equipment::WeaponSlot, new EquipmentItem(
-            name: $this->equipment->getEmptyName(Equipment::WeaponSlot),
-            strength: 0,
-            value: 0,
-        ));
-        $this->equipment->setItemInSlot(Equipment::ArmorSlot, new EquipmentItem(
-            name: $this->equipment->getEmptyName(Equipment::ArmorSlot),
-            strength: 0,
-            value: 0,
-        ));
+        $characterBefore = clone $this->character;
 
-        // Later, offer the possibility to change this behaviour by raising events.
-        //$this->eventDispatcher->dispatch();
+        $this->character->level = 1;
+
+        $this->eventDispatcher->dispatch(
+            event: new CharacterChangeEvent($this->character, $characterBefore),
+            eventName: self::OnCharacterReset
+        );
     }
 }

--- a/src/Game/Scene/SceneTemplate/TrainingTemplate.php
+++ b/src/Game/Scene/SceneTemplate/TrainingTemplate.php
@@ -11,6 +11,7 @@ use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Entity\Paragraph;
+use LotGD2\Event\CharacterChangeEvent;
 use LotGD2\Form\Scene\SceneTemplate\TrainingTemplateType;
 use LotGD2\Game\Battle\Battle;
 use LotGD2\Game\Character\Equipment;
@@ -24,6 +25,7 @@ use LotGD2\Repository\MasterRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -45,13 +47,15 @@ class TrainingTemplate implements SceneTemplateInterface
     use DefaultSceneTemplate;
     use DefaultFightTrait;
 
-    const ActionGroupTraining = "lotgd2.actionGroup.trainingTemplate.training";
-    const ActionQuestion = "lotgd2.action.trainingTemplate.question";
-    const ActionChallenge = "lotgd2.action.trainingTemplate.challenge";
+    const string ActionGroupTraining = "lotgd2.actionGroup.trainingTemplate.training";
+    const string ActionQuestion = "lotgd2.action.trainingTemplate.question";
+    const string ActionChallenge = "lotgd2.action.trainingTemplate.challenge";
+    const string OnCharacterLevelUp = 'lotgd2.event.TrainingTemplate.levelUp';
 
     public function __construct(
         private readonly Security $security,
         private readonly LoggerInterface $logger,
+        private readonly EventDispatcherInterface $eventDispatcher,
         private readonly AttachmentRepository $attachmentRepository,
         private readonly MasterRepository $masterRepository,
         private readonly DiceBagInterface $diceBag,
@@ -242,9 +246,7 @@ class TrainingTemplate implements SceneTemplateInterface
      */
     public function onFightWon(BattleState $battleState): void
     {
-        $this->stats->levelUp();
-        $this->health->heal();
-
+        $this->levelUp();
 
         $this->stage->paragraphs = [
             new Paragraph(
@@ -342,14 +344,22 @@ class TrainingTemplate implements SceneTemplateInterface
                     scene: $this->scene,
                     title: "#! Unsee master",
                     parameters: ["op" => "cheat", "what" => "unseeMaster"],
-                    reference: "lotgd2.action.fightTemplate.cheats.experience",
+                    reference: "lotgd2.action.fightTemplate.cheats.unseeMaster",
                 ),
                 new Action(
                     scene: $this->scene,
                     title: "#! Gain 1 level",
                     parameters: ["op" => "cheat", "what" => "levelUp"],
-                    reference: "lotgd2.action.fightTemplate.cheats.gold",)
+                    reference: "lotgd2.action.fightTemplate.cheats.levelUp",
+                ),
+                new Action(
+                    scene: $this->scene,
+                    title: "#! Set level to 15",
+                    parameters: ["op" => "cheat", "what" => "level15"],
+                    reference: "lotgd2.action.fightTemplate.cheats.level15",
+                ),
             ]);
+
             $this->stage->addActionGroup($cheatsGroup);
         }
     }
@@ -359,7 +369,29 @@ class TrainingTemplate implements SceneTemplateInterface
         if ($cheat === "unseeMaster") {
             $this->setSeenMaster($character);
         } elseif ($cheat === "levelUp") {
-            $this->stats->levelUp();
+            $this->levelUp();
+        } elseif ($cheat === "level15") {
+            $this->levelUp(15);
         }
+    }
+
+    /**
+     * @return void
+     */
+    public function levelUp(?int $targetLevel = null): void
+    {
+        $oldCharacter = clone $this->character;
+
+        if ($targetLevel === null) {
+            $level = 1;
+        } else {
+            $level = $targetLevel - $this->character->level;
+        }
+
+        $this->character->level += $level;
+        $this->logger->debug("{$this->character}: Level increased to {$this->character->level}.");
+        $event = new CharacterChangeEvent($this->character, $oldCharacter);
+
+        $this->eventDispatcher->dispatch($event, self::OnCharacterLevelUp);
     }
 }

--- a/src/Repository/RaceRepository.php
+++ b/src/Repository/RaceRepository.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Repository;
+
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use LotGD2\Entity\Mapped\Race;
+
+/**
+ * @extends ServiceEntityRepository<Race>
+ */
+class RaceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Race::class);
+    }
+}

--- a/src/Twig/Component/Live/Game.php
+++ b/src/Twig/Component/Live/Game.php
@@ -49,7 +49,7 @@ class Game extends AbstractController
     {
         $health = new Health(null, $this->character);
         $equipment = new Equipment(null, $this->character);
-        $stats = new Stats(null, $equipment, $health, $this->character);
+        $stats = new Stats(null, $equipment, $this->character);
         $gold = new Gold(null, $this->character);
         $race = new Race(null, null, null, $this->raceRepository);
 

--- a/src/Twig/Component/Live/Game.php
+++ b/src/Twig/Component/Live/Game.php
@@ -8,8 +8,10 @@ use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Game\Character\Equipment;
 use LotGD2\Game\Character\Gold;
 use LotGD2\Game\Character\Health;
+use LotGD2\Game\Character\Race;
 use LotGD2\Game\Character\Stats;
 use LotGD2\Game\GameLoop;
+use LotGD2\Repository\RaceRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
@@ -29,6 +31,7 @@ class Game extends AbstractController
 
     public function __construct(
         private readonly GameLoop $game,
+        private readonly RaceRepository $raceRepository,
     ) {
     }
 
@@ -48,10 +51,12 @@ class Game extends AbstractController
         $equipment = new Equipment(null, $this->character);
         $stats = new Stats(null, $equipment, $health, $this->character);
         $gold = new Gold(null, $this->character);
+        $race = new Race(null, null, null, $this->raceRepository);
 
         return [
             ["Character"],
             ["Name", $this->character->name],
+            ["Race", $race->getRaceName($this->character)],
             ["Level", $this->character->level],
             ["Experience", $stats->getExperience()],
             ["Turns", $health->getTurns(), $health->getMaxTurns()],

--- a/src/Twig/Component/Live/Game.php
+++ b/src/Twig/Component/Live/Game.php
@@ -77,6 +77,10 @@ class Game extends AbstractController
         #[LiveArg]
         string $actionId,
     ): void {
+        if ($this->character === null) {
+            throw $this->createNotFoundException("Character disappeared");
+        }
+
         $this->game->setCharacter($this->character);
         $stage = $this->game->takeAction($this->character, $actionId);
     }

--- a/tests/Entity/ActionTest.php
+++ b/tests/Entity/ActionTest.php
@@ -7,6 +7,7 @@ use LotGD2\Entity\Action;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Game\Random\DiceBag;
 use LotGD2\Game\Random\DiceBagInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -14,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Action::class)]
 #[UsesClass(DiceBag::class)]
+#[AllowMockObjectsWithoutExpectations]
 class ActionTest extends TestCase
 {
     public function testConstructorWithoutParameters(): void

--- a/tests/Entity/Battle/BattleRoundMessageTest.php
+++ b/tests/Entity/Battle/BattleRoundMessageTest.php
@@ -5,10 +5,12 @@ namespace LotGD2\Tests\Entity\Battle;
 
 use LotGD2\Entity\Battle\BattleRoundMessage;
 use LotGD2\Entity\Battle\BattleMessage;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(BattleRoundMessage::class)]
+#[AllowMockObjectsWithoutExpectations]
 class BattleRoundMessageTest extends TestCase
 {
     private BattleRoundMessage $battleRoundMessage;

--- a/tests/Entity/Battle/BattleStateTest.php
+++ b/tests/Entity/Battle/BattleStateTest.php
@@ -7,6 +7,7 @@ use LotGD2\Entity\Battle\BattleRoundMessage;
 use LotGD2\Entity\Battle\CurrentCharacterFighter;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Game\Character\Health;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -21,6 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[UsesClass(BattleMessage::class)]
 #[UsesClass(BattleRoundMessage::class)]
 #[UsesClass(Health::class)]
+#[AllowMockObjectsWithoutExpectations]
 class BattleStateTest extends TestCase
 {
     private FighterInterface&MockObject $goodGuyMock;

--- a/tests/Entity/Battle/CurrentCharacterFighterTest.php
+++ b/tests/Entity/Battle/CurrentCharacterFighterTest.php
@@ -8,6 +8,7 @@ use LotGD2\Entity\Mapped\Character;
 use LotGD2\Game\Character\Equipment;
 use LotGD2\Game\Character\Health;
 use LotGD2\Game\Character\Stats;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -17,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(Health::class)]
 #[UsesClass(Stats::class)]
 #[UsesClass(Equipment::class)]
+#[AllowMockObjectsWithoutExpectations]
 class CurrentCharacterFighterTest extends TestCase
 {
     public function testCharacterIsClonedProperlyAsAFighter(): void

--- a/tests/Entity/Mapped/CharacterTest.php
+++ b/tests/Entity/Mapped/CharacterTest.php
@@ -5,11 +5,13 @@ namespace LotGD2\Tests\Entity\Mapped;
 
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Mapped\Stage;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Character::class)]
+#[AllowMockObjectsWithoutExpectations]
 class CharacterTest extends TestCase
 {
     public function testEmptyConstructor()

--- a/tests/Entity/Mapped/SceneActionGroupTest.php
+++ b/tests/Entity/Mapped/SceneActionGroupTest.php
@@ -7,10 +7,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\SceneActionGroup;
 use LotGD2\Entity\Mapped\SceneConnection;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(SceneActionGroup::class)]
+#[AllowMockObjectsWithoutExpectations]
 class SceneActionGroupTest extends TestCase
 {
     public function testEmptyConstructor()

--- a/tests/Entity/Mapped/SceneTest.php
+++ b/tests/Entity/Mapped/SceneTest.php
@@ -13,6 +13,7 @@ use LotGD2\Entity\Mapped\SceneConnection;
 use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Game\Enum\SceneConnectionType;
 use LotGD2\Game\Scene\SceneTemplate\SceneTemplateInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -21,6 +22,7 @@ use ValueError;
 
 #[CoversClass(Scene::class)]
 #[UsesClass(SceneConnection::class)]
+#[AllowMockObjectsWithoutExpectations]
 class SceneTest extends TestCase
 {
     public function testEmptyConstructor()

--- a/tests/Entity/Mapped/StageTest.php
+++ b/tests/Entity/Mapped/StageTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
 use PHPUnit\Framework\TestCase;
 use TypeError;
+use ValueError;
 
 #[CoversClass(Stage::class)]
 #[AllowMockObjectsWithoutExpectations]
@@ -263,6 +264,7 @@ class StageTest extends TestCase
         $action = $this->createMock(Action::class);
 
         // Should not throw an error, just do nothing
+        $this->expectException(ValueError::class);
         $result = $stage->addAction('non-existent', $action);
 
         $this->assertSame($stage, $result);

--- a/tests/Entity/Mapped/StageTest.php
+++ b/tests/Entity/Mapped/StageTest.php
@@ -30,11 +30,10 @@ class StageTest extends TestCase
         $this->assertNull($stage->id);
         $this->assertNull($stage->owner);
         $this->assertNull($stage->title);
-        $this->assertNull($stage->description);
         $this->assertNull($stage->scene);
         $this->assertEquals([], $stage->actionGroups);
         $this->assertNull($stage->attachments);
-        $this->assertNull($stage->context);
+        $this->assertEmpty($stage->paragraphs);
     }
 
     public function testConstructorWithAllParameters()

--- a/tests/Entity/Mapped/StageTest.php
+++ b/tests/Entity/Mapped/StageTest.php
@@ -11,12 +11,14 @@ use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Entity\Paragraph;
 use LotGD2\Game\Scene\SceneAttachment\SceneAttachmentInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
 #[CoversClass(Stage::class)]
+#[AllowMockObjectsWithoutExpectations]
 class StageTest extends TestCase
 {
     public function testEmptyConstructor()

--- a/tests/Game/Battle/BattleEvent/AbstractBattleEventTest.php
+++ b/tests/Game/Battle/BattleEvent/AbstractBattleEventTest.php
@@ -6,10 +6,12 @@ namespace LotGD2\Tests\Game\Battle\BattleEvent;
 use LotGD2\Entity\Battle\FighterInterface;
 use LotGD2\Game\Battle\BattleEvent\AbstractBattleEvent;
 use LotGD2\Game\Error\BattleEventError;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(AbstractBattleEvent::class)]
+#[AllowMockObjectsWithoutExpectations]
 class AbstractBattleEventTest extends TestCase
 {
     private AbstractBattleEvent $battleEvent;

--- a/tests/Game/Battle/BattleEvent/CriticalHitEventTest.php
+++ b/tests/Game/Battle/BattleEvent/CriticalHitEventTest.php
@@ -6,6 +6,7 @@ use LotGD2\Entity\Battle\BattleMessage;
 use LotGD2\Entity\Battle\CurrentCharacterFighter;
 use LotGD2\Entity\Battle\FighterInterface;
 use LotGD2\Game\Battle\BattleEvent\CriticalHitEvent;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -13,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 #[CoversClass(CriticalHitEvent::class)]
 #[UsesClass(BattleMessage::class)]
+#[AllowMockObjectsWithoutExpectations]
 class CriticalHitEventTest extends TestCase
 {
     private FighterInterface $attacker;

--- a/tests/Game/Battle/BattleEvent/DamageEventTest.php
+++ b/tests/Game/Battle/BattleEvent/DamageEventTest.php
@@ -6,6 +6,7 @@ use LotGD2\Entity\Battle\BattleMessage;
 use LotGD2\Entity\Battle\CurrentCharacterFighter;
 use LotGD2\Entity\Battle\FighterInterface;
 use LotGD2\Game\Battle\BattleEvent\DamageEvent;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -13,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 #[CoversClass(DamageEvent::class)]
 #[UsesClass(BattleMessage::class)]
+#[AllowMockObjectsWithoutExpectations]
 class DamageEventTest extends TestCase
 {
     private FighterInterface $attacker;

--- a/tests/Game/Battle/BattleEvent/DeathEventTest.php
+++ b/tests/Game/Battle/BattleEvent/DeathEventTest.php
@@ -7,6 +7,7 @@ use LotGD2\Entity\Battle\BattleMessage;
 use LotGD2\Entity\Battle\CurrentCharacterFighter;
 use LotGD2\Entity\Battle\FighterInterface;
 use LotGD2\Game\Battle\BattleEvent\DeathEvent;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -18,6 +19,7 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
 #[CoversClass(DeathEvent::class)]
 #[UsesClass(BattleMessage::class)]
+#[AllowMockObjectsWithoutExpectations]
 class DeathEventTest extends TestCase
 {
     private FighterInterface $attacker;

--- a/tests/Game/Battle/BattleTest.php
+++ b/tests/Game/Battle/BattleTest.php
@@ -25,6 +25,7 @@ use LotGD2\Game\Character\Equipment;
 use LotGD2\Game\Character\Health;
 use LotGD2\Game\Character\Stats;
 use LotGD2\Game\Random\DiceBag;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -53,6 +54,7 @@ use Symfony\Component\Serializer\Serializer;
 #[UsesClass(BattleMessage::class)]
 #[UsesClass(BattleRoundMessage::class)]
 #[UsesClass(DeathEvent::class)]
+#[AllowMockObjectsWithoutExpectations]
 class BattleTest extends KernelTestCase
 {
     private Battle $battle;

--- a/tests/Game/Battle/BattleTurnTest.php
+++ b/tests/Game/Battle/BattleTurnTest.php
@@ -28,14 +28,12 @@ class BattleTurnTest extends TestCase
 {
     private BattleTurn $battleTurn;
     private MockObject&DiceBagInterface $diceBag;
-    private MockObject&BattleState $battleState;
     private MockObject&CurrentCharacterFighter $currentCharacterFighter;
     private MockObject&FighterInterface $fighter;
 
     protected function setUp(): void
     {
         $this->diceBag = $this->createMock(DiceBagInterface::class);
-        $this->battleState = $this->createMock(BattleState::class);
         $this->currentCharacterFighter = $this->createMock(CurrentCharacterFighter::class);
         $this->fighter = $this->createMock(FighterInterface::class);
         

--- a/tests/Game/Battle/BattleTurnTest.php
+++ b/tests/Game/Battle/BattleTurnTest.php
@@ -11,6 +11,7 @@ use LotGD2\Game\Battle\BattleEvent\CriticalHitEvent;
 use LotGD2\Game\Battle\BattleEvent\DamageEvent;
 use LotGD2\Game\Battle\BattleTurn;
 use LotGD2\Game\Random\DiceBagInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -22,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(BattleState::class)]
 #[UsesClass(DamageEvent::class)]
 #[UsesClass(CriticalHitEvent::class)]
+#[AllowMockObjectsWithoutExpectations]
 class BattleTurnTest extends TestCase
 {
     private BattleTurn $battleTurn;

--- a/tests/Game/Character/DragonCounterTest.php
+++ b/tests/Game/Character/DragonCounterTest.php
@@ -13,6 +13,7 @@ use LotGD2\Game\Character\DragonCounter;
 use LotGD2\Game\Character\Health;
 use LotGD2\Game\Character\Stats;
 use LotGD2\Game\Random\DiceBagInterface;
+use LotGD2\Game\Stage\ActionService;
 use PhpParser\Builder\Property;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -22,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[CoversClass(DragonCounter::class)]
 #[UsesClass(Action::class)]
@@ -36,6 +38,7 @@ class DragonCounterTest extends TestCase
     private Character&MockObject $character;
     private Stats&MockObject $stats;
     private Health&MockObject $health;
+    private ActionService&MockObject $actionService;
 
     protected function setUp(): void
     {
@@ -45,6 +48,7 @@ class DragonCounterTest extends TestCase
         $this->character = $this->createMock(Character::class);
         $this->health = $this->createMock(Health::class);
         $this->stats = $this->createMock(Stats::class);
+        $this->actionService = $this->createMock(ActionService::class);
 
         $this->dragonCounter = new DragonCounter(
             $this->logger,
@@ -53,6 +57,7 @@ class DragonCounterTest extends TestCase
             $this->character,
             $this->health,
             $this->stats,
+            $this->actionService,
         );
     }
 

--- a/tests/Game/Character/EquipmentTest.php
+++ b/tests/Game/Character/EquipmentTest.php
@@ -6,6 +6,7 @@ namespace LotGD2\Tests\Game\Character;
 use LotGD2\Entity\Character\EquipmentItem;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Game\Character\Equipment;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,7 @@ use Psr\Log\LoggerInterface;
 #[CoversClass(Equipment::class)]
 #[UsesClass(Character::class)]
 #[UsesClass(EquipmentItem::class)]
+#[AllowMockObjectsWithoutExpectations]
 class EquipmentTest extends TestCase
 {
     public function testGetEquipment(): void

--- a/tests/Game/Character/GoldTest.php
+++ b/tests/Game/Character/GoldTest.php
@@ -5,6 +5,7 @@ namespace LotGD2\Tests\Game\Character;
 
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Game\Character\Gold;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -13,6 +14,7 @@ use Psr\Log\LoggerInterface;
 
 #[CoversClass(Gold::class)]
 #[UsesClass(Character::class)]
+#[AllowMockObjectsWithoutExpectations]
 class GoldTest extends TestCase
 {
     public static function getGoldProvider(): array

--- a/tests/Game/Character/HealthTest.php
+++ b/tests/Game/Character/HealthTest.php
@@ -5,6 +5,7 @@ namespace LotGD2\Tests\Game\Character;
 
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Game\Character\Health;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -14,6 +15,7 @@ use Psr\Log\LoggerInterface;
 
 #[CoversClass(Health::class)]
 #[UsesClass(Character::class)]
+#[AllowMockObjectsWithoutExpectations]
 final class HealthTest extends TestCase
 {
     public static function getHealthProvider(): array

--- a/tests/Game/Character/StatsTest.php
+++ b/tests/Game/Character/StatsTest.php
@@ -211,7 +211,6 @@ class StatsTest extends TestCase
         $statsWithNullLogger = new Stats(
             null,
             $this->equipment,
-            $this->health,
             $this->character
         );
 
@@ -308,7 +307,6 @@ class StatsTest extends TestCase
         $statsWithNullLogger = new Stats(
             null,
             $this->equipment,
-            $this->health,
             $this->character
         );
 
@@ -437,102 +435,6 @@ class StatsTest extends TestCase
             ->willReturn($armor);
 
         $this->assertEquals($expectedTotal, $this->stats->getTotalDefense());
-    }
-
-    public function testLevelUpIncreasesLevel(): void
-    {
-        $currentLevel = 5;
-        $expectedNewLevel = 6;
-
-        $this->character
-            ->expects($this->exactly(2))
-            ->method(PropertyHook::get("level"))
-            ->willReturn($currentLevel, $expectedNewLevel);
-
-        $this->character
-            ->expects($this->once())
-            ->method(PropertyHook::set("level"))
-            ->with($expectedNewLevel);
-
-        $this->character
-            ->expects($this->atLeastOnce())
-            ->method(PropertyHook::get("id"))
-            ->willReturn(6);
-
-        // Mock the calls for addAttack and addDefense
-        $this->character
-            ->method('getProperty')
-            ->willReturnMap([
-                [Stats::AttackPropertyName, 1, 10],
-                [Stats::AttackPropertyName, 1, 10], // Called again in debug
-                [Stats::DefensePropertyName, 1, 11],
-            ]);
-
-        $this->character
-            ->expects($this->exactly(2))
-            ->method('setProperty')
-            ->willReturnMap([
-                [Stats::AttackPropertyName, 11, $this->character],
-                [Stats::DefensePropertyName, 12, $this->character],
-            ]);
-
-        $this->health
-            ->expects($this->once())
-            ->method('addMaxHealth')
-            ->with(10);
-
-        $result = $this->stats->levelUp();
-
-        $this->assertSame($this->stats, $result);
-    }
-
-    public function testLevelUpWithNullLogger(): void
-    {
-        $statsWithNullLogger = new Stats(
-            null,
-            $this->equipment,
-            $this->health,
-            $this->character
-        );
-
-        $currentLevel = 5;
-        $expectedNewLevel = 6;
-
-        $this->character
-            ->expects($this->exactly(1))
-            ->method(PropertyHook::get("level"))
-            ->willReturn($currentLevel);
-
-        $this->character
-            ->expects($this->once())
-            ->method(PropertyHook::set("level"))
-            ->with($expectedNewLevel);
-
-        // Mock the calls for addAttack and addDefense
-        $this->character
-            ->expects($this->exactly(2))
-            ->method('getProperty')
-            ->willReturnMap([
-                [Stats::AttackPropertyName, 1, 10],
-                [Stats::DefensePropertyName, 1, 11],
-            ]);
-
-        $this->character
-            ->expects($this->exactly(2))
-            ->method('setProperty')
-            ->willReturnMap([
-                [Stats::AttackPropertyName, 11, $this->character],
-                [Stats::DefensePropertyName, 12, $this->character],
-            ]);
-
-        $this->health
-            ->expects($this->once())
-            ->method('addMaxHealth')
-            ->with(10);
-
-        $result = $statsWithNullLogger->levelUp();
-
-        $this->assertSame($statsWithNullLogger, $result);
     }
 
     public function testMultipleExperienceAdditions(): void

--- a/tests/Game/Character/StatsTest.php
+++ b/tests/Game/Character/StatsTest.php
@@ -8,12 +8,14 @@ use LotGD2\Entity\Mapped\Character;
 use LotGD2\Game\Character\Equipment;
 use LotGD2\Game\Character\Health;
 use LotGD2\Game\Character\Stats;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 #[CoversClass(Stats::class)]
+#[AllowMockObjectsWithoutExpectations]
 class StatsTest extends TestCase
 {
     private Stats $stats;
@@ -32,7 +34,6 @@ class StatsTest extends TestCase
         $this->stats = new Stats(
             $this->logger,
             $this->equipment,
-            $this->health,
             $this->character
         );
     }

--- a/tests/Game/Character/StatsTest.php
+++ b/tests/Game/Character/StatsTest.php
@@ -21,7 +21,6 @@ class StatsTest extends TestCase
     private Stats $stats;
     private Character $character;
     private Equipment $equipment;
-    private Health $health;
     private ?LoggerInterface $logger;
 
     protected function setUp(): void
@@ -29,7 +28,6 @@ class StatsTest extends TestCase
         $this->character = $this->createMock(Character::class);
         $this->equipment = $this->createMock(Equipment::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->health = $this->createMock(Health::class);
 
         $this->stats = new Stats(
             $this->logger,

--- a/tests/Game/Scene/SceneRendererTest.php
+++ b/tests/Game/Scene/SceneRendererTest.php
@@ -21,6 +21,7 @@ use LotGD2\Game\Random\DiceBag;
 use LotGD2\Game\Scene\SceneRenderer;
 use LotGD2\Game\Stage\ActionService;
 use LotGD2\Repository\SceneRepository;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -43,6 +44,7 @@ use Psr\Log\LoggerInterface;
 #[UsesClass(Stats::class)]
 #[UsesClass(ExpressionService::class)]
 #[UsesClass(Paragraph::class)]
+#[AllowMockObjectsWithoutExpectations]
 class SceneRendererTest extends TestCase
 {
     private SceneRenderer $renderer;

--- a/tests/Game/Scene/SceneTemplate/FightTemplateTest.php
+++ b/tests/Game/Scene/SceneTemplate/FightTemplateTest.php
@@ -23,6 +23,7 @@ use LotGD2\Game\Scene\SceneAttachment\BattleAttachment;
 use LotGD2\Game\Scene\SceneTemplate\FightTemplate;
 use LotGD2\Repository\AttachmentRepository;
 use LotGD2\Repository\CreatureRepository;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -37,6 +38,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 #[UsesClass(DiceBag::class)]
 #[UsesClass(Paragraph::class)]
 #[UsesClass(BattleState::class)]
+#[AllowMockObjectsWithoutExpectations]
 class FightTemplateTest extends TestCase
 {
     private FightTemplate $fightTemplate;

--- a/tests/Game/Scene/SceneTemplate/HealerTemplateTest.php
+++ b/tests/Game/Scene/SceneTemplate/HealerTemplateTest.php
@@ -13,6 +13,7 @@ use LotGD2\Game\Character\Gold;
 use LotGD2\Game\Character\Health;
 use LotGD2\Game\Random\DiceBag;
 use LotGD2\Game\Scene\SceneTemplate\HealerTemplate;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -26,6 +27,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 #[UsesClass(ActionGroup::class)]
 #[UsesClass(DiceBag::class)]
 #[UsesClass(Paragraph::class)]
+#[AllowMockObjectsWithoutExpectations]
 class HealerTemplateTest extends TestCase
 {
     private HealerTemplate $healerTemplate;

--- a/tests/Game/Stage/ActionServiceTest.php
+++ b/tests/Game/Stage/ActionServiceTest.php
@@ -9,6 +9,7 @@ use LotGD2\Entity\ActionGroup;
 use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Game\Random\DiceBag;
 use LotGD2\Game\Stage\ActionService;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
@@ -18,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(DiceBag::class)]
 #[UsesClass(Action::class)]
 #[UsesClass(ActionGroup::class)]
+#[AllowMockObjectsWithoutExpectations]
 class ActionServiceTest extends TestCase
 {
     private ActionService $actionService;


### PR DESCRIPTION
This PR adds races to the game.

Fixes #22 

Races are database based entities optionally powered by a Class implementing the RaceInterface. The interface has two methods: onSelect and onDeselect, allowing implementing classes to add changes and revert them. The Race handler (`Game\Character\Race`) allows to get race name, race class and, especially important, race configuration - which is the configuration of the race **at the time of it setting**. This neat feature allows to accurately revert the changes even if the race itself got changed afterwards. Also the class name is still retained on the character, in case that one got exchanged, too.

Other features:
- Introduces a CharacterChangeEvent which is raised by the DragonTemplate on character reset (`DragonTemplate::onCharacterReset`) and the TrainingTemplate on level up (`DragonTemplate::onCharacterLevelUp`). The handling of level up / character reset was moved into the corresponding character handlers as event listeners.
- New days allow the selection of a race if not yet set
- Race selection comes _after_ dragon point distribution, just like the original.
- StandardRace also hooks into PostNewDay to add turns for Humans
- All 5 races from 0.9.7+jt ext GER 3 are available inside the fixtures: Humans (extra turns), Trolls (extra attack), Elves (extra defense), Dwarfes (extra loot, not yet implemented) and Lizards (extra health).
- Lizards gain 2 health points as one seems a bit unfair compared to the others. Maybe I plan to offer the possibility to have extra health point _each level_ instead.