### PR TITLE
Refactoring: Moved standard battle logic out of DefaultFightTrait into Battle.php using events.

### DIFF
--- a/src/Event/BattleNavigationChangeEvent.php
+++ b/src/Event/BattleNavigationChangeEvent.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Event;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use LotGD2\Entity\Action;
+use LotGD2\Entity\ActionGroup;
+use LotGD2\Entity\Battle\BattleState;
+use LotGD2\Entity\Mapped\Character;
+use LotGD2\Entity\Mapped\Scene;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BattleNavigationChangeEvent extends Event
+{
+    /**
+     * @param Character $character
+     * @param BattleState $battleState
+     * @param ActionGroup[] $actionGroups
+     */
+    public function __construct(
+        protected(set) Character $character,
+        protected(set) BattleState $battleState,
+        protected(set) array $actionGroups,
+        protected(set) Scene $scene,
+        protected(set) array $actionParams,
+    ) {
+
+    }
+
+    /**
+     * @param string $title
+     * @param string $reference
+     * @param array<string, mixed> $parameters
+     * @return Action
+     */
+    public function getAction(string $title, string $reference, array $parameters): Action
+    {
+        return new Action(
+            scene: $this->scene,
+            title: $title,
+            parameters: [
+                ... $parameters,
+                ... $this->actionParams,
+                "battleState" => $this->battleState
+            ],
+            reference: $reference,
+        );
+    }
+
+    /**
+     * @param ActionGroup $actionGroup
+     * @return void
+     */
+    public function addActionGroup(ActionGroup $actionGroup): void
+    {
+        $this->actionGroups[] = $actionGroup;
+    }
+}

--- a/src/Event/BattleNavigationChangeEvent.php
+++ b/src/Event/BattleNavigationChangeEvent.php
@@ -17,6 +17,8 @@ class BattleNavigationChangeEvent extends Event
      * @param Character $character
      * @param BattleState $battleState
      * @param ActionGroup[] $actionGroups
+     * @param Scene $scene
+     * @param array<string, mixed> $actionParams
      */
     public function __construct(
         protected(set) Character $character,

--- a/src/Event/BattleSkillActivationEvent.php
+++ b/src/Event/BattleSkillActivationEvent.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Event;
+use LotGD2\Entity\Mapped\Character;
+use LotGD2\Game\Handler\BuffHandler;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BattleSkillActivationEvent extends Event
+{
+    public function __construct(
+        public readonly Character $character,
+        public readonly BuffHandler $buff,
+        public readonly string $skillName,
+    ) {
+    }
+}

--- a/src/Event/SimpleStageParameterEvent.php
+++ b/src/Event/SimpleStageParameterEvent.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Event;
+
+use LotGD2\Entity\Action;
+use LotGD2\Entity\Mapped\Character;
+use LotGD2\Entity\Mapped\Scene;
+use LotGD2\Entity\Mapped\Stage;
+use LotGD2\Game\Random\DiceBagAwareInterface;
+use LotGD2\Game\Random\DiceBagAwareTrait;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SimpleStageParameterEvent extends Event
+{
+    protected(set) Character $character;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $params;
+
+    public function __construct(
+        protected(set) Stage $stage,
+        protected(set) Action $action,
+        protected(set) Scene $scene,
+        mixed ... $params
+    ) {
+        $this->character = $stage->owner;
+        $this->params = $params;
+    }
+}

--- a/src/Game/Battle/Battle.php
+++ b/src/Game/Battle/Battle.php
@@ -24,7 +24,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
-use function round;
 
 /**
  * @phpstan-import-type BattleEventCollection from BattleEventInterface
@@ -147,7 +146,7 @@ class Battle
     }
 
     /**
-     * Fights exactly one round (1 offense and 1 defense turn)
+     * Fights exactly one round (1 offence and 1 defence turn)
      * @param BattleState $battleState
      * @param int $damageRound
      * @return void
@@ -161,16 +160,16 @@ class Battle
         $goodGuyBuffs = $this->buffHandler->getBuffs($this->character);
         $badGuyBuffs = $this->buffHandler->getBuffs($battleState->badGuy);
 
-        // Activate on round start comes before the calculation of the half turns
+        // Activate on round start comes before the calculation of the half-turns
         $goodGuyBuffStartEvents = $goodGuyBuffs->activate(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->goodGuy, $battleState->badGuy);
         $badGuyBuffStartEvents = $badGuyBuffs->activate(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->badGuy, $battleState->goodGuy);
 
         [$offenseTurn, $defenseTurn] = $this->turn->getHalfTurns($battleState, $goodGuyBuffs, $badGuyBuffs);
 
-        // Only add offense turns if its part of the current round
+        // Only add offence turns if it's part of the current round
         $offenseTurnEvents = $damageRound & BattleTurn::DamageTurnGoodGuy ? $offenseTurn : [];
 
-        // Only add defense turns if its part of the current round
+        // Only add defence turns if it's part of the current round
         $defenseTurnEvents = $damageRound & BattleTurn::DamageTurnBadGuy ? $defenseTurn : [];
 
         // Activate on round end.

--- a/src/Game/Battle/Battle.php
+++ b/src/Game/Battle/Battle.php
@@ -14,14 +14,25 @@ use LotGD2\Entity\Battle\Fighter;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
+use LotGD2\Entity\Paragraph;
 use LotGD2\Event\BattleNavigationChangeEvent;
+use LotGD2\Event\BattleSkillActivationEvent;
+use LotGD2\Event\SimpleStageParameterEvent;
+use LotGD2\Event\StageChangeEvent;
 use LotGD2\Game\Battle\BattleEvent\BattleEventInterface;
 use LotGD2\Game\Battle\BattleEvent\DamageEvent;
 use LotGD2\Game\Battle\BattleEvent\DeathEvent;
+use LotGD2\Game\GameLoop;
 use LotGD2\Game\Handler\BuffHandler;
+use LotGD2\Game\Random\DiceBagInterface;
+use LotGD2\Game\Scene\SceneAttachment\BattleAttachment;
+use LotGD2\Game\Scene\SceneRenderer;
+use LotGD2\Game\Stage\ActionService;
+use LotGD2\Repository\AttachmentRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -42,14 +53,29 @@ class Battle
     const string FightActionAutoAll = "lotgd2.action.autoAll";
 
     const string OnAddFightActions = "lotgd2.event.battle.addFightActions";
+    const string OnSkillActivationEvent = "lotgd2.event.DefaultFight.skillActivationEvent";
+    const string OnFightFlee = "lotgd2.event.DefaultFight.flee";
+    const string OnFightFled = "lotgd2.event.DefaultFight.fled";
+    const string OnFightEnds = "lotgd2.event.DefaultFight.ends";
+
+    const string FightOpParamValue = "fight";
+    const string SurpriseActionParam = "surprise";
+    const string FightActionParam = "how";
+    const string FleeFightActionParamValue = "flee";
+    const string SkillFightActionParamValue = "skill";
+    const string SkillActionParam = "skill";
+    const string RoundsActionParam = "rounds";
 
     public function __construct(
         private LoggerInterface $logger,
         private readonly ?Stopwatch $stopWatch,
         private EventDispatcherInterface $eventDispatcher,
-        private readonly ?Security $security,
         private readonly DenormalizerInterface&NormalizerInterface $normalizer,
         private readonly BattleTurn $turn,
+        private readonly SceneRenderer $sceneRenderer,
+        private readonly ActionService $actionService,
+        private readonly AttachmentRepository $attachmentRepository,
+        private readonly DiceBagInterface $diceBag,
         private readonly BuffHandler $buffHandler,
         #[Autowire(expression: "service('lotgd2.game_loop').getCharacter()")]
         private Character $character,
@@ -91,6 +117,7 @@ class Battle
     public function addFightActions(Stage $stage, Scene $scene, BattleState $battleState, array $actionParams = []): void
     {
         $this->logger->debug("Adding Battle Actions");
+        $this->actionService->resetActionGroups($stage);
 
         $actionGroups = [
             new ActionGroup(self::ActionGroupBattle, "Fight", -100)
@@ -228,5 +255,130 @@ class Battle
         }
 
         return $eventsToAdd;
+    }
+
+    #[AsEventListener(GameLoop::OnBeforeSameSceneChange)]
+    public function onBeforeSameSceneChange(StageChangeEvent $event): StageChangeEvent
+    {
+        $battleState = $event->action->getParameter("battleState");
+
+        if (!($battleState instanceof BattleState)) {
+            return $event;
+        }
+
+        // Find attachment
+        $attachment = $this->attachmentRepository->findOneByAttachmentClass(BattleAttachment::class);
+
+        if (!$attachment) {
+            // If attachment was not found, exit event without stopping propagation.
+            $this->logger->critical("Attachment not found.");
+            return $event;
+        }
+
+        // Manually reset stage
+        $event->stage->clearParagraphs();
+        $event->stage->clearAttachments();
+        $this->actionService->resetActionGroups($event->stage);
+
+        // Make sure the changes made here are not overwritten by the default event handling.
+        $event->stopPropagation();
+
+        // What has been selected in the fight?
+        $how = $event->action->getParameter(self::FightActionParam);
+
+        $event->stage->paragraphs = [
+            new Paragraph(
+                id: "lotgd2.paragraph.DefaultFightTrait.FightMessage",
+                text: "You are in the middle of the fight against <.{{ badGuy.name }}.>.",
+                context: [
+                    "badGuy" => $battleState->badGuy,
+                ]
+            )
+        ];
+
+        //
+        if ($event->action->getParameter(self::SurpriseActionParam, false) === true) {
+            $battleTurn = BattleTurn::DamageTurnGoodGuy;
+        } else {
+            $battleTurn = BattleTurn::DamageTurnBoth;
+        }
+
+        // Handle 'flee' options
+        if ($battleState->allowFlee and $how === self::FleeFightActionParamValue) {
+            // If "flee" was used, we dispatch an event and delegate its handling to somewhere else
+            // But we do offer a default event listener inside the battle class with low priority
+            $simpleStageEvent = new SimpleStageParameterEvent($event->stage, $event->action, $event->scene, success: false, punishment: false);
+            $simpleStageEvent = $this->eventDispatcher->dispatch($simpleStageEvent, self::OnFightFlee);
+
+            if ($simpleStageEvent->params["success"] === true) {
+                // If character has fled successfully, we emit another event allowing scenes to reset navigation
+                $fightFledEvent = new SimpleStageParameterEvent($event->stage, $event->action, $event->scene);
+                $fightFledEvent = $this->eventDispatcher->dispatch($fightFledEvent, self::OnFightFled);
+
+                // Return on success
+                return $event;
+            }
+
+            if ($simpleStageEvent->params["punishment"] === true) {
+                $battleTurn = BattleTurn::DamageTurnBadGuy;
+            }
+        }
+
+        // Handle 'skill activation'
+        if ($how === self::SkillFightActionParamValue) {
+            $skill = $event->action->getParameter(self::SkillActionParam);
+
+            $battleSkillActivationEvent = new BattleSkillActivationEvent($event->character, $this->buffHandler, $skill);
+            $this->eventDispatcher->dispatch($battleSkillActivationEvent, self::OnSkillActivationEvent);
+        }
+
+        $event->stage->addAttachment($attachment, data: [
+            "battleState" => $battleState,
+        ]);
+
+        $rounds = $event->action->getParameter(self::RoundsActionParam) ?? 1;
+
+        do {
+            $rounds -= 1;
+            $this->fightOneRound($battleState, $battleTurn);
+
+            if ($battleState->isOver()) {
+                break;
+            }
+
+            // If ¨$rounds is not 0, we continue with the next round. If $rounds is 0, we stop.
+            // That means, if rounds is negative, the fight continues until someone dies.
+            $anotherOne = $rounds !== 0;
+
+            // Set battle Turn back to default to remove the 'surprised' element after the first round.
+            $battleTurn = BattleTurn::DamageTurnBoth;
+        } while ($anotherOne);
+
+        if ($battleState->isOver()) {
+            $simpleStageEvent = new SimpleStageParameterEvent($event->stage, $event->action, $event->scene, battleState: $battleState);
+            $simpleStageEvent = $this->eventDispatcher->dispatch($simpleStageEvent, self::OnFightEnds);
+
+            $this->sceneRenderer->addActions($event->stage, $event->scene);
+        } else {
+            // Only add fight actions if the fight is not over
+            $this->addFightActions($event->stage, $event->scene, $battleState, ["op" => self::FightOpParamValue]);
+        }
+
+        return $event;
+    }
+
+    #[AsEventListener(self::OnFightFlee, priority: -100)]
+    public function onFightFlee(SimpleStageParameterEvent $event): SimpleStageParameterEvent
+    {
+        if ($event->action->getParameter(self::SurpriseActionParam, false) === true || $this->diceBag->chance(0.3333, precision: 4)) {
+            $this->logger->critical("Successfully escaped from the enemy.");
+
+            $event->params["success"] = true;
+        } else {
+            $event->params["success"] = false;
+            $event->params["punishment"] = true;
+        }
+
+        return $event;
     }
 }

--- a/src/Game/Battle/Battle.php
+++ b/src/Game/Battle/Battle.php
@@ -14,6 +14,7 @@ use LotGD2\Entity\Battle\Fighter;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
+use LotGD2\Event\BattleNavigationChangeEvent;
 use LotGD2\Game\Battle\BattleEvent\BattleEventInterface;
 use LotGD2\Game\Battle\BattleEvent\DamageEvent;
 use LotGD2\Game\Battle\BattleEvent\DeathEvent;
@@ -24,6 +25,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @phpstan-import-type BattleEventCollection from BattleEventInterface
@@ -39,9 +41,12 @@ class Battle
     const string FightActionAutoTen = "lotgd2.action.auto10";
     const string FightActionAutoAll = "lotgd2.action.autoAll";
 
+    const string OnAddFightActions = "lotgd2.event.battle.addFightActions";
+
     public function __construct(
         private LoggerInterface $logger,
         private readonly ?Stopwatch $stopWatch,
+        private EventDispatcherInterface $eventDispatcher,
         private readonly ?Security $security,
         private readonly DenormalizerInterface&NormalizerInterface $normalizer,
         private readonly BattleTurn $turn,
@@ -86,63 +91,52 @@ class Battle
     public function addFightActions(Stage $stage, Scene $scene, BattleState $battleState, array $actionParams = []): void
     {
         $this->logger->debug("Adding Battle Actions");
-        $actionGroup = new ActionGroup(self::ActionGroupBattle, "Fight", -100);
 
-        $actionGroup->setActions([
-            new Action($scene, "Attack", [... $actionParams, "how" => "attack", "battleState" => $battleState], reference: self::FightActionAttack),
-        ]);
+        $actionGroups = [
+            new ActionGroup(self::ActionGroupBattle, "Fight", -100)
+                ->setActions([
+                    new Action($scene, "Attack", [... $actionParams, "how" => "attack", "battleState" => $battleState], reference: self::FightActionAttack),
+                ]),
+            new ActionGroup(self::ActionGroupAutoBattle, "Auto", -90)
+                ->setActions([
+                    new Action(
+                        $scene,
+                        "for 5 rounds", [
+                        ... $actionParams,
+                        "how" => "attack",
+                        "rounds" => 5,
+                        "battleState" => $battleState],
+                        reference: self::FightActionAutoFive,
+                    ),
+                    new Action(
+                        $scene,
+                        "for 10 rounds", [
+                        ... $actionParams,
+                        "how" => "attack",
+                        "rounds" => 10,
+                        "battleState" => $battleState],
+                        reference: self::FightActionAutoTen,
+                    ),
+                    new Action(
+                        $scene,
+                        "until the bitter end", [
+                        ... $actionParams,
+                        "how" => "attack",
+                        "rounds" => -1,
+                        "battleState" => $battleState],
+                        reference: self::FightActionAutoAll,
+                    ),
+                ])
+        ];
 
         if ($battleState->allowFlee) {
-            $actionGroup->addAction(new Action($scene, "Flee", [... $actionParams, "how" => "flee", "battleState" => $battleState], reference: self::FightActionFlee));
+            $actionGroups[0]->addAction(new Action($scene, "Flee", [... $actionParams, "how" => "flee", "battleState" => $battleState], reference: self::FightActionFlee));
         }
 
-        $autoActionGroup = new ActionGroup(self::ActionGroupAutoBattle, "Auto", -99);
-        $autoActionGroup->setActions([
-            new Action(
-                $scene,
-                "for 5 rounds", [
-                    ... $actionParams,
-                    "how" => "attack",
-                    "rounds" => 5,
-                    "battleState" => $battleState],
-                reference: self::FightActionAutoFive,
-            ),
-            new Action(
-                $scene,
-                "for 10 rounds", [
-                ... $actionParams,
-                "how" => "attack",
-                "rounds" => 10,
-                "battleState" => $battleState],
-                reference: self::FightActionAutoTen,
-            ),
-            new Action(
-                $scene,
-                "until the bitter end", [
-                ... $actionParams,
-                "how" => "attack",
-                "rounds" => -1,
-                "battleState" => $battleState],
-                reference: self::FightActionAutoAll,
-            ),
-        ]);
+        $battleNavigationEvent = new BattleNavigationChangeEvent($this->character, $battleState, $actionGroups, $scene, $actionParams);
+        $battleNavigationEvent = $this->eventDispatcher->dispatch($battleNavigationEvent, self::OnAddFightActions);
 
-        $stage->addActionGroup($actionGroup);
-        $stage->addActionGroup($autoActionGroup);
-
-        if ($this->security->isGranted("ROLE_CHEATS_ENABLED")) {
-            $cheatActionGroup = new ActionGroup("nothing", "Auto", -200);
-            $actionGroup->addAction(new Action(
-                $scene,
-                "God mode", [
-                ... $actionParams,
-                "how" => "skill",
-                "skill" => "godmode",
-                "battleState" => $battleState],
-                reference: self::FightActionAutoAll,
-            ));
-            $stage->addActionGroup($cheatActionGroup);
-        }
+        array_map(fn (ActionGroup $actionGroup) => $stage->addActionGroup($actionGroup), $battleNavigationEvent->actionGroups);
     }
 
     /**

--- a/src/Game/Battle/BattleTurn.php
+++ b/src/Game/Battle/BattleTurn.php
@@ -33,11 +33,13 @@ readonly class BattleTurn
 
     /**
      * Processes a half-turn.
-     * @internal
      * @param BattleState $battleState
      * @param FighterInterface $attacker
      * @param FighterInterface $defender
+     * @param BuffList $attackersBuffs
+     * @param BuffList $defendersBuffs
      * @return ArrayCollection<int, AbstractBattleEvent>
+     * @internal
      */
     public function partialTurn(
         BattleState $battleState,
@@ -53,7 +55,7 @@ readonly class BattleTurn
 
         [$attackersAttack, $defendersDefense] = $this->calculateAttackAndDefense($battleState, $attacker, $defender, $attackersBuffs, $defendersBuffs);
 
-        // Lets "roll the dice".
+        // Lets "roll the dice" to determine damage.
         $attackersAtkRoll = $this->diceBag->pseudoBell(0, $attackersAttack);
         $defendersDefRoll = $this->diceBag->pseudoBell(0, $defendersDefense);
         $damage = $attackersAtkRoll - $defendersDefRoll;
@@ -76,10 +78,10 @@ readonly class BattleTurn
             // Both are invulnerable. We cannot set the damage to 0.
             $damage = 1;
         } elseif ($attackerIsInvulnerable) {
-            // Attaker is invulnurable, damage is always > 0 (there is no riposte)
+            // Attacker is invulnerable, damage is always > 0 (there is no riposte)
             $damage = abs($damage);
         } elseif ($defenderIsInvulnerable) {
-            // Defender is invulnurable, damage is always < 0 (defender always ripostes)
+            // Defender is invulnerable, damage is always < 0 (defender always ripostes)
             $damage = -abs($damage);
         }
 
@@ -90,8 +92,8 @@ readonly class BattleTurn
         //  damage increases.
         if ($damage < 0) {
             if ($battleState->isRiposteEnabled) {
-                // If the damage is less then 0, it's a RIPOSTE. They are only half
-                // as damaging than normal attacks.
+                // If the damage is less than 0, it's a RIPOSTE. They are only half
+                // as damaging as normal attacks.
                 $damage /= 2;
 
                 // Apply damage modification. It's a RIPOSTE, so the defender makes the damage. Therefore, we need to take
@@ -105,8 +107,8 @@ readonly class BattleTurn
                 $damage = 0;
             }
         } else {
-            // Apply damage modification. It normal attack, so the attacker makes the damage. Therefore, we need to take
-            //  the attackers's goodGuyDamagerModifier into account and the defenders's badGuyDamageModifier
+            // Apply damage modification. It is a normal attack, so the attacker makes the damage. Therefore, we need to take
+            //  the attacker's goodGuyDamagerModifier into account and the defender's badGuyDamageModifier
             $damage *= $attackersBuffs->goodGuyDamageModifier
                 * $defendersBuffs->badGuyDamageModifier;
 
@@ -122,15 +124,25 @@ readonly class BattleTurn
         // Add the damage event
         $events->add(new DamageEvent($attacker, $defender, ["damage" => $damage]));
 
-        // Do all the other buff effects. Modifiers are calculated separatly and do not need activation
+        // Do all the other buff effects. Modifiers are calculated separately and do not need activation
+
+        // Activates buffs to yield "activation" messages if necessary. Only activated buffs are processed by the BuffList
         $attackersBuffStartEvents = $attackersBuffs->activate(Buff::ACTIVATES_ON_OFFENSE_TURN, $attacker, $defender);
         $defendersBuffStartEvents = $defendersBuffs->activate(Buff::ACTIVATES_ON_DEFENSE_TURN, $attacker, $defender);
 
+        // Process direct buffs. Direct buffs are buffs that summon minions that cause damage
         $attackersDirectBuffEvents = $attackersBuffs->processDirectBuffs(Buff::ACTIVATES_ON_OFFENSE_TURN, $attacker, $defender);
         $defendersDirectBuffEvents = $defendersBuffs->processDirectBuffs(Buff::ACTIVATES_ON_DEFENSE_TURN, $defender, $attacker);
 
+        // Process damage-dependent buffs like life tap or damage reflection
         $attackersDamageDependentBuffEvents = $attackersBuffs->processDamageDependentBuffs(Buff::ACTIVATES_ON_OFFENSE_TURN, $damage, $attacker, $defender);
         $defendersDamageDependentBuffEvents = $defendersBuffs->processDamageDependentBuffs(Buff::ACTIVATES_ON_DEFENSE_TURN, -$damage, $defender, $attacker);
+
+        // The sequence of battle events does not depend on the status of the current round. We can freely resort the events now.
+        // First, the attacker's buffs are announced and applied
+        // Then, the defender's buffs are announced and applied
+        // Then the normal battle-round begins
+        // Damage-dependent buffs come last. Life-saving life-taps only help if the applicant doesn't die (yet).
 
         $events = new ArrayCollection([
             ...$attackersBuffStartEvents,
@@ -162,9 +174,11 @@ readonly class BattleTurn
         $i = 0;
 
         // Repeat as long as possible to prevent rounds where nobody hits.
+        // This is how fights worked in 0.9.7+jt. Damages caused by buffs _do not count_.
         while (true) {
             $this->logger->debug("BattleTurn: Try #{$i}");
 
+            // Evaluate both half-turns (offense and defense)
             $offenseTurn = $this->partialTurn($battleState, $battleState->goodGuy, $battleState->badGuy, $goodGuyBuffList, $badGuyBuffList);
             $defenseTurn = $this->partialTurn($battleState, $battleState->badGuy, $battleState->goodGuy, $badGuyBuffList, $goodGuyBuffList);
 
@@ -173,9 +187,11 @@ readonly class BattleTurn
                 "defense" => $defenseTurn,
             ]);
 
+            // Return any raised DamageEvent.
             $offenseDamageEvent = $offenseTurn->findFirst(fn(int $k, BattleEventInterface $e) => $e instanceof DamageEvent);
             $defenseDamageEvent = $defenseTurn->findFirst(fn(int $k, BattleEventInterface $e) => $e instanceof DamageEvent);
 
+            // If this was the 21st time, let's call it a day. The probability of this result changing is at this point trivial
             if ($i >= 20) {
                 $this->logger->critical("There is something wrong with a battle; it should not need 20 evaluations.", context: [
                     "battleState" => $battleState,
@@ -188,6 +204,7 @@ readonly class BattleTurn
                 break;
             }
 
+            // If at least one of the two damage events is not zero, we stop the cycle to return the events.
             if ((
                     $offenseDamageEvent instanceof DamageEvent and $offenseDamageEvent->getDamage() <> 0
                 ) || (
@@ -203,15 +220,17 @@ readonly class BattleTurn
     }
 
     /**
-     * Makes different adjustments to the attacker's attack and the defenders defense and returns the modified values
+     * Makes different adjustments to the attacker's attack and the defender's defense and returns the modified values
      * Adjustments:
-     *  - Level adjustment (defenders with lower levels have decreased defense; such with higher levels have increased defense)
+     *  - Level adjustment (defenders with lower levels have decreased defense; such with higher levels has increased defense)
      *  - Critical hit adjustments
      *  - Buffs (later)
      *
      * @param BattleState $battleState
      * @param FighterInterface $attacker
      * @param FighterInterface $defender
+     * @param BuffList $attackersBuffs
+     * @param BuffList $defendersBuffs
      * @return int[]
      */
     public function calculateAttackAndDefense(
@@ -224,11 +243,11 @@ readonly class BattleTurn
         $adjustment = 1.0;
         $defenseAdjustment = 1.0;
 
-        // Adjustement makes fights versus monsters with lower level easier;
+        // Adjustment makes fights versus monsters with lower level easier;
         // and more difficult if the monster has a higher level by adjusting
         // the monster's defense value.
         // For example, if a level 10 player attacks a level 9 monster, the
-        // defenseAdjustement value for the monster is 0.81, reducing the monster's
+        // defenseAdjustment value for the monster is 0.81, reducing the monster's
         // defense by 20% and making it more likely for the player to land a hit.
         // On the other hand, the player's defense is increased by ~ 10%, making it
         // less likely for the enemy to hit the player.

--- a/src/Game/GameLoop.php
+++ b/src/Game/GameLoop.php
@@ -9,6 +9,7 @@ use LotGD2\Entity\ActionGroup;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
+use LotGD2\Event\StageChangeEvent;
 use LotGD2\Game\Error\InvalidActionError;
 use LotGD2\Game\GameTime\NewDay;
 use LotGD2\Game\Scene\SceneRenderer;
@@ -21,11 +22,14 @@ use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[AsAlias(id: "lotgd2.game_loop", public: true)]
 #[Autoconfigure(public: true)]
 class GameLoop
 {
+    const string OnBeforeSameSceneChange = "lotgd2.event.GameLoop.BeforeSameSceneChange";
+
     private ContainerInterface $container;
 
     private ?Character $character = null;
@@ -35,6 +39,7 @@ class GameLoop
         readonly private Stopwatch $stopwatch,
         readonly private EntityManagerInterface $entityManager,
         readonly private LoggerInterface $logger,
+        readonly private EventDispatcherInterface $dispatcher,
         readonly private SceneRenderer $renderer,
         readonly private SceneRepository $sceneRepository,
         readonly private ActionService $actionService,
@@ -107,6 +112,13 @@ class GameLoop
 
             if ($renderDefault && $targetScene?->templateClass !== null and !$skipOnSceneEnter) {
                 $renderDefault = $this->renderOnSceneEnter($stage, $selectedAction, $currentScene, $targetScene);
+            }
+        } else {
+            $sceneChangeEvent = new StageChangeEvent($character->stage, $selectedAction, $currentScene);
+            $sceneChangeEvent = $this->dispatcher->dispatch($sceneChangeEvent, self::OnBeforeSameSceneChange);
+
+            if ($sceneChangeEvent->isPropagationStopped()) {
+                $renderDefault = false;
             }
         }
 

--- a/src/Game/Handler/SpecialtyHandler.php
+++ b/src/Game/Handler/SpecialtyHandler.php
@@ -3,15 +3,70 @@ declare(strict_types=1);
 
 namespace LotGD2\Game\Handler;
 
+use LotGD2\Entity\Action;
+use LotGD2\Entity\ActionGroup;
+use LotGD2\Entity\Battle\Buff;
+use LotGD2\Event\BattleNavigationChangeEvent;
+use LotGD2\Event\BattleSkillActivationEvent;
+use LotGD2\Game\Battle\Battle;
 use LotGD2\Game\Random\DiceBagInterface;
+use LotGD2\Game\Scene\SceneTemplate\DefaultFightTrait;
+use LotGD2\Game\Scene\SceneTemplate\FightTemplate;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
 class SpecialtyHandler
 {
+    const string ActionGodMode = "lotgd2.action.SpecialtyHandler.godMode";
+
     public function __construct(
-        private ?LoggerInterface $logger = null, // @phpstan-ignore property.onlyWritten
+        private LoggerInterface $logger, // @phpstan-ignore property.onlyWritten
+        private Security $security,
         private ?DiceBagInterface $diceBag = null, // @phpstan-ignore property.onlyWritten
     ) {
 
+    }
+
+    #[AsEventListener(Battle::OnAddFightActions)]
+    public function onBattleNavigationAddCheats(BattleNavigationChangeEvent $event): void
+    {
+        if (!$this->security->isGranted("ROLE_CHEATS_ENABLED")) return;
+
+        $cheatActionGroup = new ActionGroup("nothing", "Cheats", -80);
+        $cheatActionGroup->addAction($event->getAction(
+            title: "God mode",
+            reference: self::ActionGodMode,
+            parameters: [
+                "how" => "skill",
+                "skill" => "godmode",
+            ]
+        ));
+
+        $event->addActionGroup($cheatActionGroup);
+    }
+
+    #[AsEventListener(FightTemplate::OnSkillActivationEvent)]
+    public function onSkillActivationEvent(BattleSkillActivationEvent $event): void
+    {
+        if (!$this->security->isGranted("ROLE_CHEATS_ENABLED")) return;
+
+        if ($event->skillName === "godmode") {
+            $this->logger->debug("{$event->character}: Godmode buff called.");
+
+            $event->buff->addBuff($event->character, new Buff(
+                id: "lotgd2.buff.DefaultFightTrait.GodMode",
+                name: "GOD MODE",
+                activatesAt: Buff::ACTIVATES_ON_ROUNDSTART,
+                rounds: 1,
+                startMessage: "You feel god-like",
+                endMessage: "You are mortal again",
+                goodGuyAttackModifier: 25,
+                goodGuyDefenseModifier: 25,
+                goodGuyInvulnerable: true,
+            ));
+
+            $event->stopPropagation();
+        }
     }
 }

--- a/src/Game/Handler/SpecialtyHandler.php
+++ b/src/Game/Handler/SpecialtyHandler.php
@@ -9,6 +9,8 @@ use LotGD2\Entity\Battle\Buff;
 use LotGD2\Event\BattleNavigationChangeEvent;
 use LotGD2\Event\BattleSkillActivationEvent;
 use LotGD2\Game\Battle\Battle;
+use LotGD2\Game\Random\DiceBagAwareInterface;
+use LotGD2\Game\Random\DiceBagAwareTrait;
 use LotGD2\Game\Random\DiceBagInterface;
 use LotGD2\Game\Scene\SceneTemplate\DefaultFightTrait;
 use LotGD2\Game\Scene\SceneTemplate\FightTemplate;
@@ -16,14 +18,15 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
-class SpecialtyHandler
+class SpecialtyHandler implements DiceBagAwareInterface
 {
+    use DiceBagAwareTrait;
+
     const string ActionGodMode = "lotgd2.action.SpecialtyHandler.godMode";
 
     public function __construct(
-        private LoggerInterface $logger, // @phpstan-ignore property.onlyWritten
+        private LoggerInterface $logger,
         private Security $security,
-        private ?DiceBagInterface $diceBag = null, // @phpstan-ignore property.onlyWritten
     ) {
 
     }

--- a/src/Game/Random/DiceBagAwareInterface.php
+++ b/src/Game/Random/DiceBagAwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Game\Random;
+
+interface DiceBagAwareInterface
+{
+    public DiceBagInterface $diceBag {
+        get;
+        set;
+    }
+}

--- a/src/Game/Random/DiceBagAwareTrait.php
+++ b/src/Game/Random/DiceBagAwareTrait.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Game\Random;
+
+// @phpstan-ignore trait.unused
+trait DiceBagAwareTrait
+{
+    public DiceBagInterface $diceBag {
+        get {
+            if (!isset($this->diceBag)) {
+                $this->diceBag = new DiceBag();
+            }
+
+            return $this->diceBag;
+        }
+        set => $value;
+    }
+}

--- a/src/Game/Scene/SceneTemplate/DefaultFightTrait.php
+++ b/src/Game/Scene/SceneTemplate/DefaultFightTrait.php
@@ -10,6 +10,7 @@ use LotGD2\Entity\Character\LootBag;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Entity\Paragraph;
+use LotGD2\Event\BattleSkillActivationEvent;
 use LotGD2\Event\LootBagEvent;
 use LotGD2\Game\Battle\BattleStateStatusEnum;
 use LotGD2\Game\Battle\BattleTurn;
@@ -31,6 +32,7 @@ trait DefaultFightTrait
 
     const string OnLootBagFill = "lotgd2.event.DefaultFight.lootBagFill";
     const string OnLootBagClaim = "lotgd2.event.DefaultFight.lootBagClaim";
+    const string OnSkillActivationEvent = "lotgd2.event.DefaultFight.skillActivationEvent";
 
     public function fightAction(): void {
         $how = $this->action->getParameter("how");
@@ -70,24 +72,12 @@ trait DefaultFightTrait
                 }
             }
 
-            if ($how === "skill") {
+            if ($how === "skill" and $this->stage->owner) {
+                // I feel like this handling here generally should move to Battle class
                 $skill = $this->action->getParameter("skill");
 
-                if ($skill === "godmode") {
-                    $this->logger->debug("{$this->stage->owner}: Godmode buff called.");
-
-                    $this->buffs->addBuff($this->stage->owner, new Buff(
-                        id: "lotgd2.buff.DefaultFightTrait.GodMode",
-                        name: "GOD MODE",
-                        activatesAt: Buff::ACTIVATES_ON_ROUNDSTART,
-                        rounds: 1,
-                        startMessage: "You feel god-like",
-                        endMessage: "You are mortal again",
-                        goodGuyAttackModifier: 25,
-                        goodGuyDefenseModifier: 25,
-                        goodGuyInvulnerable: true,
-                    ));
-                }
+                $battleSkillActivationEvent = new BattleSkillActivationEvent($this->stage->owner, $this->buffs, $skill);
+                $this->eventDispatcher->dispatch($battleSkillActivationEvent, self::OnSkillActivationEvent);
             }
 
             $this->stage->addAttachment($attachment, data: [

--- a/src/Game/Scene/SceneTemplate/DefaultFightTrait.php
+++ b/src/Game/Scene/SceneTemplate/DefaultFightTrait.php
@@ -3,30 +3,23 @@ declare(strict_types=1);
 
 namespace LotGD2\Game\Scene\SceneTemplate;
 
-use LotGD2\Entity\Action;
 use LotGD2\Entity\Battle\BattleState;
-use LotGD2\Entity\Battle\Buff;
-use LotGD2\Entity\Character\LootBag;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Entity\Paragraph;
-use LotGD2\Event\BattleSkillActivationEvent;
 use LotGD2\Event\LootBagEvent;
+use LotGD2\Event\SimpleStageParameterEvent;
+use LotGD2\Game\Battle\Battle;
 use LotGD2\Game\Battle\BattleStateStatusEnum;
-use LotGD2\Game\Battle\BattleTurn;
-use LotGD2\Game\Handler\BuffHandler;
 use LotGD2\Game\Handler\GoldHandler;
 use LotGD2\Game\Handler\StatsHandler;
-use LotGD2\Game\Random\DiceBagInterface;
-use LotGD2\Game\Scene\SceneAttachment\BattleAttachment;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 trait DefaultFightTrait
 {
-    private readonly DiceBagInterface $diceBag;
     private readonly GoldHandler $gold;
     private readonly StatsHandler $stats;
-    private readonly BuffHandler $buffs;
     private readonly EventDispatcherInterface $eventDispatcher;
     private Stage $stage;
 
@@ -34,93 +27,13 @@ trait DefaultFightTrait
     const string OnLootBagClaim = "lotgd2.event.DefaultFight.lootBagClaim";
     const string OnSkillActivationEvent = "lotgd2.event.DefaultFight.skillActivationEvent";
 
-    public function fightAction(): void {
-        $how = $this->action->getParameter("how");
-        $battleState = $this->action->getParameter("battleState");
-
-        if (!$battleState instanceof BattleState) {
-            $this->onBattleStateDisappeared();
-            $this->logger->critical("The BattleState was not transferred correctly", $this->action->getParameters());
-            return;
-        }
-
-        // Find attachment
-        $attachment = $this->attachmentRepository->findOneByAttachmentClass(BattleAttachment::class);
-
-        if ($attachment) {
-            $this->stage->paragraphs = [
-                new Paragraph(
-                    id: "lotgd2.paragraph.DefaultFightTrait.FightMessage",
-                    text: "You are in the middle of the fight against <.{{ badGuy.name }}.>.",
-                    context: [
-                        "badGuy" => $battleState->badGuy,
-                    ]
-                )
-            ];
-
-            if ($this->action->getParameter("surprise", false) === true) {
-                $battleTurn = BattleTurn::DamageTurnGoodGuy;
-            } else {
-                $battleTurn = BattleTurn::DamageTurnBoth;
-            }
-
-            if ($how === "flee") {
-                $success = $this->onFightFlee($battleTurn);
-
-                if ($success) {
-                    return;
-                }
-            }
-
-            if ($how === "skill" and $this->stage->owner) {
-                // I feel like this handling here generally should move to Battle class
-                $skill = $this->action->getParameter("skill");
-
-                $battleSkillActivationEvent = new BattleSkillActivationEvent($this->stage->owner, $this->buffs, $skill);
-                $this->eventDispatcher->dispatch($battleSkillActivationEvent, self::OnSkillActivationEvent);
-            }
-
-            $this->stage->addAttachment($attachment, data: [
-                "battleState" => $battleState,
-            ]);
-
-            $rounds = $this->action->getParameter("rounds") ?? 1;
-
-            do {
-                $rounds -= 1;
-                $this->battle->fightOneRound($battleState, $battleTurn);
-
-                if ($battleState->isOver()) {
-                    break;
-                }
-
-                // If ¨$rounds is not 0, we continue with the next round. If $rounds is 0, we stop.
-                // That means, if rounds is negative, the fight continues until someone dies.
-                $anotherOne = $rounds !== 0;
-
-                // Set battle Turn back to default to remove the 'surprised' element after the first round.
-                $battleTurn = BattleTurn::DamageTurnBoth;
-            } while ($anotherOne);
-
-            if ($battleState->isOver()) {
-                $this->onFightEnds($battleState);
-            } else {
-                // Only add fight actions if the fight is not over
-                $this->stage->clearActionGroups();
-                $this->battle->addFightActions($this->stage, $this->scene, $battleState, ["op" => "fight"]);
-            }
-        } else {
-            $this->logger->critical("Cannot attach attachment " . BattleAttachment::class . ": Not installed.");
-        }
-    }
-
     /**
      * Redefine what happens if the battle state disappears
      * @return void
      */
     public function onBattleStateDisappeared(): void
     {
-        $this->addDefaultActions();
+        $this->addDefaultActions($this->stage, $this->scene);
         $this->stage->paragraphs = [
             new Paragraph(
                 id: "lotgd2.paragraph.DefaultFightTrait.SuddenFightEnd",
@@ -132,54 +45,37 @@ trait DefaultFightTrait
     /**
      * Whenever a fight ends (expected or unexpected), the state can be reused to search for the next fight. This
      * method offers a hook to add additional default actions (besides the usual scene connections).
+     * @param Stage $stage
+     * @param Scene $scene
      * @return void
      */
-    public function addDefaultActions(): void
+    public function addDefaultActions(Stage $stage, Scene $scene): void
     {
 
     }
 
-    /**
-     * Method that decides what happens when a character flees. By changing the return value, the battle turn type can
-     * be overwritten from the previous value.
-     *
-     * By default, a failed flee action will result in a battle turn where only the enemy attacks.
-     * @param int $battleTurn
-     * @return bool
-     */
-    public function onFightFlee(int &$battleTurn): bool
+    #[AsEventListener(Battle::OnFightFled, priority: -50)]
+    public function onFightFled(SimpleStageParameterEvent $event): void
     {
-        if ($this->action->getParameter("surprise", false) === true || $this->diceBag->chance(0.3333, precision: 4)) {
-            $this->logger->critical("Successfully escaped from the enemy.");
-
-            $this->stage->paragraphs = [
-                new Paragraph(
-                    id: "lotgd.paragraph.DefaultFightTrait.onFlightFlee",
-                    text: "You have successfully fled your opponent!",
-                ),
-                new Paragraph(
-                    id: Stage::SceneText,
-                    text: $this->scene->description,
-                )
-            ];
-
-            // Add standard navigation
-            $this->addDefaultActions();
-
-            return true;
-        } else {
-            // Fleeing failed - meaning only the enemy gets to attack
-            $this->stage->paragraphs = [
-                new Paragraph(
-                    id: "lotgd.paragraph.DefaultFightTrait.onFlightFleeFailed",
-                    text: "You failed to flee your opponent! You are too busy trying to run away like a cowardly dog to try to fight!",
-                ),
-            ];
-
-            $battleTurn = BattleTurn::DamageTurnBadGuy;
-
-            return false;
+        if ($event->scene->templateClass !== self::class) {
+            // Only catch events on scenes with the current class
+            // Multiple scenes are using this trait, so there will be multiple classes listening in automatically
+            return;
         }
+
+        $event->stage->paragraphs = [
+            new Paragraph(
+                id: "lotgd.paragraph.DefaultFightTrait.onFlightFlee",
+                text: "You have successfully fled your opponent!",
+            ),
+            new Paragraph(
+                id: Stage::SceneText,
+                text: $this->scene->description,
+            )
+        ];
+
+        // Add standard navigation
+        $this->addDefaultActions($event->stage, $event->scene);
     }
 
     /**
@@ -187,28 +83,39 @@ trait DefaultFightTrait
      *
      * If no special code is necessary, decisions can also be shifted to onFightWon and onFightList to only change
      * what happens in these specific cases.
-     * @param BattleState $battleState
+     * @param SimpleStageParameterEvent $event
      * @return void
      */
-    public function onFightEnds(BattleState $battleState): void
+    #[AsEventListener(Battle::OnFightEnds, priority: -50)]
+    public function onFightEnds(SimpleStageParameterEvent $event): void
     {
+        if ($event->scene->templateClass !== self::class) {
+            // Only catch events on scenes with the current class
+            // Multiple scenes are using this trait, so there will be multiple classes listening in automatically
+            return;
+        }
+
+        /** @var BattleState $battleState */
+        $battleState = $event->params["battleState"];
+
         if ($battleState->result === BattleStateStatusEnum::GoodGuyWon) {
-            $this->onFightWon($battleState);
+            $this->onFightWon($event, $battleState);
         } else {
-            $this->onFightLost($battleState);
+            $this->onFightLost($event, $battleState);
         }
 
         // Add standard navigation if battle is over
-        $this->addDefaultActions();
+        $this->addDefaultActions($event->stage, $event->scene);
     }
 
     /**
      * Handles the event triggered when a fight is won by the character.
      *
+     * @param SimpleStageParameterEvent $event
      * @param BattleState $battleState
      * @return void
      */
-    public function onFightWon(BattleState $battleState): void
+    public function onFightWon(SimpleStageParameterEvent $event, BattleState $battleState): void
     {
         # Only dispatch event and create loot if the event dispatcher has been set.
         if (isset($this->eventDispatcher)) {
@@ -219,7 +126,7 @@ trait DefaultFightTrait
             $lootBagEvent = null;
         }
 
-        $this->stage->paragraphs = [
+        $event->stage->paragraphs = [
             new Paragraph(
                 id: "lotgd.paragraph.DefaultFightTrait.onFightWon",
                 text:<<<TEXT
@@ -236,7 +143,7 @@ trait DefaultFightTrait
         if ($lootBagEvent instanceof LootBagEvent) {
             $lootBag = $lootBagEvent->lootBag;
             $lootBag->lock();
-            $lootBagEvent = new LootBagEvent($battleState, $lootBag, $this->stage);
+            $lootBagEvent = new LootBagEvent($battleState, $lootBag, $event->stage);
             $this->eventDispatcher->dispatch($lootBagEvent, self::OnLootBagClaim);
         } else {
             $this->logger->critical("Loot bag event disappeared.", ["event", $lootBagEvent]);
@@ -250,15 +157,16 @@ trait DefaultFightTrait
      * Sets the stage description to reflect that the fight has been lost, detailing the penalties incurred.
      * Logs the event and adjusts the gold and experience of the character to represent the loss.
      *
+     * @param SimpleStageParameterEvent $event
      * @param BattleState $battleState The state of the battle at the time of the loss.
      *
      * @return void
      */
-    public function onFightLost(BattleState $battleState): void
+    public function onFightLost(SimpleStageParameterEvent $event, BattleState $battleState): void
     {
         $experienceLost = (int)round(0.1 * $this->stats->getExperience());
 
-        $this->stage->paragraphs = [
+        $event->stage->paragraphs = [
             new Paragraph(
                 id: "lotgd.paragraph.DefaultFightTrait.onFightLost",
                 text: <<<TEXT
@@ -276,7 +184,7 @@ trait DefaultFightTrait
             ),
         ];
 
-        $this->logger->debug("Character {$this->stage->owner->id} has been slain and lost {$this->gold->getGold(null)}.");
+        $this->logger->debug("Character {$event->character->id} has been slain and lost {$this->gold->getGold(null)}.");
         $this->gold->setGold(null, 0);
         $this->stats->addExperience(-$experienceLost);
     }

--- a/src/Game/Scene/SceneTemplate/DragonTemplate.php
+++ b/src/Game/Scene/SceneTemplate/DragonTemplate.php
@@ -10,14 +10,13 @@ use LotGD2\Entity\Battle\BattleState;
 use LotGD2\Entity\Battle\Fighter;
 use LotGD2\Entity\Paragraph;
 use LotGD2\Event\CharacterChangeEvent;
+use LotGD2\Event\SimpleStageParameterEvent;
 use LotGD2\Form\Scene\SceneTemplate\DragonTemplateType;
 use LotGD2\Game\Battle\Battle;
-use LotGD2\Game\Handler\BuffHandler;
 use LotGD2\Game\Handler\DragonCounterHandler;
 use LotGD2\Game\Handler\GoldHandler;
 use LotGD2\Game\Handler\StatsHandler;
 use LotGD2\Game\GameTime\NewDay;
-use LotGD2\Game\Random\DiceBagInterface;
 use LotGD2\Game\Scene\SceneAttachment\BattleAttachment;
 use LotGD2\Game\Stage\ActionService;
 use LotGD2\Repository\AttachmentRepository;
@@ -49,7 +48,6 @@ class DragonTemplate implements SceneTemplateInterface
     public function __construct(
         readonly private LoggerInterface $logger,
         readonly private EventDispatcherInterface $eventDispatcher,
-        readonly private DiceBagInterface $diceBag,
         readonly private AttachmentRepository $attachmentRepository,
         readonly private SceneRepository $sceneRepository,
         readonly private Battle $battle,
@@ -58,7 +56,6 @@ class DragonTemplate implements SceneTemplateInterface
         readonly private StatsHandler $stats,
         readonly private DragonCounterHandler $dragonCounter,
         private readonly ActionService $actionService,
-        private readonly BuffHandler $buffs,
     ) {
 
     }
@@ -70,7 +67,6 @@ class DragonTemplate implements SceneTemplateInterface
         match($op) {
             default => $this->defaultAction(),
             "start" => $this->startFight(),
-            "fight" => $this->fightAction(),
             "epilogue" => $this->epilogueAction(),
         };
     }
@@ -135,16 +131,16 @@ class DragonTemplate implements SceneTemplateInterface
         ];
     }
 
-    public function onFightWon(BattleState $battleState): void
+    public function onFightWon(SimpleStageParameterEvent $event, BattleState $battleState): void
     {
         $description = <<<TEXT
             With a mighty final blow, {{ badGuy.name }} lets out a tremendous bellow and falls at your feet, dead at last.
             TEXT;
 
-        $this->logger->debug("{$this->character->id}: Victory over the Dragon.");
+        $this->logger->debug("{$event->character->id}: Victory over the Dragon.");
 
-        $this->actionService->resetActionGroups($this->stage);
-        $this->stage->addAction(
+        $this->actionService->resetActionGroups($event->stage);
+        $event->stage->addAction(
             ActionGroup::EMPTY,
             new Action(
                 scene: $this->scene,
@@ -155,9 +151,7 @@ class DragonTemplate implements SceneTemplateInterface
             )
         );
 
-        dump($this->stage);
-
-        $this->stage->paragraphs = [
+        $event->stage->paragraphs = [
             new Paragraph(
                 id: "lotgd2.paragraph.dragonTemplate.fightWon",
                 text: $description,

--- a/src/Game/Scene/SceneTemplate/FightTemplate.php
+++ b/src/Game/Scene/SceneTemplate/FightTemplate.php
@@ -52,7 +52,6 @@ class FightTemplate implements SceneTemplateInterface
         private readonly HealthHandler $health,
         private readonly StatsHandler $stats,
         private readonly GoldHandler $gold,
-        private readonly BuffHandler $buffs,
     ) {
     }
 
@@ -67,7 +66,6 @@ class FightTemplate implements SceneTemplateInterface
 
         match($op) {
             "search" => $this->searchAction(),
-            "fight" => $this->fightAction(),
             default => $this->defaultAction(),
         };
     }
@@ -87,7 +85,7 @@ class FightTemplate implements SceneTemplateInterface
             ));
         }
 
-        $this->addDefaultActions();
+        $this->addDefaultActions($this->stage ,$this->scene);
     }
 
     /**
@@ -119,7 +117,7 @@ class FightTemplate implements SceneTemplateInterface
         $creature = $this->creatureRepository->getRandomCreature($level);
 
         if (!$creature) {
-            $this->addDefaultActions();
+            $this->addDefaultActions($this->stage, $this->scene);
             $this->stage->paragraphs = [
                 new Paragraph(
                     id: "lotgd2.paragraph.fightTemplate.tooPeaceful",
@@ -185,29 +183,31 @@ class FightTemplate implements SceneTemplateInterface
             $this->stage->paragraphs = [
                 new Paragraph(
                     id: "lotgd2.paragraph.fightTemplate.noMonstersFound",
-                    text: "You are too blind to see any monsters. Maybe prey to the gods and ask for why that is?",
+                    text: "You are too blind to see any monsters. Maybe pray to the gods and ask for why that is?",
                 )
             ];
 
             $this->logger->critical("Cannot attach attachment " . BattleAttachment::class . ": Not installed.");
 
-            $this->addDefaultActions();
+            $this->addDefaultActions($this->stage, $this->scene);
         }
     }
 
     /**
      * Adds the actions required to search for a fight. The level action parameter defines the difficulty.
+     * @param Stage $stage
+     * @param Scene $scene
      * @return void
      */
-    public function addDefaultActions(): void
+    public function addDefaultActions(Stage $stage, Scene $scene): void
     {
         if ($this->health->isAlive()) {
-            $actionGroup = new ActionGroup(self::ActionGroupSearch, $this->scene->title);
+            $actionGroup = new ActionGroup(self::ActionGroupSearch, $scene->title);
 
             $actionGroup->addAction(
                 new Action(
-                    scene: $this->scene,
-                    title: $this->scene->templateConfig["searchFightAction"],
+                    scene: $scene,
+                    title: $scene->templateConfig["searchFightAction"],
                     parameters: [
                         "op" => "search",
                         "level" => 0,
@@ -218,11 +218,11 @@ class FightTemplate implements SceneTemplateInterface
             // Only allow searching for easy battles if the level is larger than 1.
             //  Enemies can only be level 1 or higher, so it wouldn't make sense
             //  to offer this option on level 1.
-            if ($this->character->level > 1) {
+            if ($stage->owner->level > 1) {
                 $actionGroup->addAction(
                     new Action(
-                        scene: $this->scene,
-                        title: $this->scene->templateConfig["searchSlummingAction"] ?? "Go slumming",
+                        scene: $scene,
+                        title: $scene->templateConfig["searchSlummingAction"] ?? "Go slumming",
                         parameters: [
                             "op" => "search",
                             "level" => -1,
@@ -233,8 +233,8 @@ class FightTemplate implements SceneTemplateInterface
 
             $actionGroup->addAction(
                 new Action(
-                    scene: $this->scene,
-                    title: $this->scene->templateConfig["searchThrillseekingAction"] ?? "Go thrillseeking",
+                    scene: $scene,
+                    title: $scene->templateConfig["searchThrillseekingAction"] ?? "Go thrillseeking",
                     parameters: [
                         "op" => "search",
                         "level" => 1,
@@ -242,26 +242,26 @@ class FightTemplate implements SceneTemplateInterface
                 )
             );
 
-            $this->stage->addActionGroup($actionGroup);
+            $stage->addActionGroup($actionGroup);
         }
 
         if ($this->security->isGranted("ROLE_CHEATS_ENABLED")) {
             $cheatsGroup = new ActionGroup("lotgd2.actionGroup.fightTemplate.cheats", "Cheats");
             $cheatsGroup->setActions([
                 new Action(
-                    scene: $this->scene,
+                    scene: $scene,
                     title: "#! Gain 1000 experience",
                     parameters: ["op" => "cheat", "what" => "experience"],
                     reference: "lotgd2.action.fightTemplate.cheats.experience",
                 ),
                 new Action(
-                    scene: $this->scene,
+                    scene: $scene,
                     title: "#! Gain 1000 gold",
                     parameters: ["op" => "cheat", "what" => "gold"],
                     reference: "lotgd2.action.fightTemplate.cheats.gold",)
             ]);
 
-            $this->stage->addActionGroup($cheatsGroup);
+            $stage->addActionGroup($cheatsGroup);
         }
     }
 
@@ -284,7 +284,7 @@ class FightTemplate implements SceneTemplateInterface
         // This is a 50% chance for 2, and a 25% chance for 1 and 3, making this effectively a 25% chance
         $level -= $this->diceBag->chance(0.25, 4) ? 1 : 0;
 
-        // There is are, effectively, 3 outcomes here:
+        // There are 3 outcomes here:
         //  -  5.47% chance for a positive increase (P(plev) * (1-P(nlev))
         //  - 11.71% chance for a negative increase ((1-P(plev) * P(nlev))
         //  - 82.81% chance for no change (1 - P(plev) * (1-P(nlev) - (1-P(plev) * P(nlev))

--- a/src/Game/Scene/SceneTemplate/TrainingTemplate.php
+++ b/src/Game/Scene/SceneTemplate/TrainingTemplate.php
@@ -8,12 +8,13 @@ use LotGD2\Entity\Action;
 use LotGD2\Entity\ActionGroup;
 use LotGD2\Entity\Battle\BattleState;
 use LotGD2\Entity\Mapped\Character;
+use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
 use LotGD2\Entity\Paragraph;
 use LotGD2\Event\CharacterChangeEvent;
+use LotGD2\Event\SimpleStageParameterEvent;
 use LotGD2\Form\Scene\SceneTemplate\TrainingTemplateType;
 use LotGD2\Game\Battle\Battle;
-use LotGD2\Game\Handler\BuffHandler;
 use LotGD2\Game\Handler\EquipmentHandler;
 use LotGD2\Game\Handler\GoldHandler;
 use LotGD2\Game\Handler\HealthHandler;
@@ -57,13 +58,11 @@ class TrainingTemplate implements SceneTemplateInterface
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly AttachmentRepository $attachmentRepository,
         private readonly MasterRepository $masterRepository,
-        private readonly DiceBagInterface $diceBag,
         private readonly Battle $battle,
         private readonly EquipmentHandler $equipment,
         private readonly StatsHandler $stats,
         private readonly HealthHandler $health,
         private readonly GoldHandler $gold, // @phpstan-ignore property.onlyWritten
-        private readonly BuffHandler $buffs,
     ) {
     }
 
@@ -93,7 +92,6 @@ class TrainingTemplate implements SceneTemplateInterface
             default => $this->defaultAction(),
             "ask" => $this->askAction(),
             "challenge" => $this->challengeAction(),
-            "fight" => $this->fightAction(),
         };
     }
 
@@ -102,6 +100,18 @@ class TrainingTemplate implements SceneTemplateInterface
         $master = $this->masterRepository->getByLevel($this->character->level);
 
         // If this returns null, the max level has been reached.
+        if ($this->health->isAlive() === false) {
+            $this->stage->paragraphs = [
+                new Paragraph(
+                    id: "lotgd2.paragraph.trainingTemplate.idDead",
+                    text: "You are dead. Dead people cannot challenge their master.",
+                    context: [],
+                )
+            ];
+
+            return;
+        }
+
         if ($master === null) {
             $this->stage->paragraphs = [
                 new Paragraph(
@@ -114,7 +124,7 @@ class TrainingTemplate implements SceneTemplateInterface
                 )
             ];
         } else {
-            $this->addDefaultActions();
+            $this->addDefaultActions($this->stage, $this->scene);
 
             $sceneParagraph = $this->stage->paragraphs[Stage::SceneText] ?? null;
             $sceneParagraph->addContext("master", $master->name);
@@ -142,7 +152,7 @@ class TrainingTemplate implements SceneTemplateInterface
             )
         ];
 
-        $this->addDefaultActions();
+        $this->addDefaultActions($this->stage, $this->scene);
     }
 
     public function challengeAction(): void
@@ -241,14 +251,15 @@ class TrainingTemplate implements SceneTemplateInterface
      * Overwrites the default onFightWon method.
      *
      * When a master has been defeated, no gold or experience is gained - instead, the level is increased.
+     * @param SimpleStageParameterEvent $event
      * @param BattleState $battleState
      * @return void
      */
-    public function onFightWon(BattleState $battleState): void
+    public function onFightWon(SimpleStageParameterEvent $event, BattleState $battleState): void
     {
-        $this->levelUp();
+        $this->levelUp($event->character);
 
-        $this->stage->paragraphs = [
+        $event->stage->paragraphs = [
             new Paragraph(
                 id: "lotgd2.paragraph.trainingTemplate.maxLevelReached",
                 text: <<<TEXT
@@ -265,28 +276,28 @@ class TrainingTemplate implements SceneTemplateInterface
                     {% endif %}
                     TEXT,
                 context: [
-                    "campLeader" => $this->scene->templateConfig["campLeader"],
+                    "campLeader" => $event->scene->templateConfig["campLeader"],
                     "badGuy" => $battleState->badGuy,
                     "maxHealth" => $this->health->getMaxHealth(),
                 ]
             )
         ];
 
-        $this->setSeenMaster($this->character, false);
-
-        $this->logger->debug("Character {$this->character->id} won against his master and is now on level {$this->character->level}.");
+        $this->setSeenMaster($event->character, false);
+        $this->logger->debug("Character {$event->character->id} won against his master and is now on level {$event->character->level}.");
     }
 
     /**
      * Overwrites the default onFightList method.
      *
      * When a fight against a master is lost, the character doesn't die, but gets healed.
+     * @param SimpleStageParameterEvent $event
      * @param BattleState $battleState
      * @return void
      */
-    public function onFightLost(BattleState $battleState): void
+    public function onFightLost(SimpleStageParameterEvent $event, BattleState $battleState): void
     {
-        $this->stage->paragraphs = [
+        $event->stage->paragraphs = [
             new Paragraph(
                 id: "lotgd2.paragraph.trainingTemplate.maxLevelReached",
                 text: <<<TEXT
@@ -296,7 +307,7 @@ class TrainingTemplate implements SceneTemplateInterface
                     {% if textLost %}<<{{ textLost }}>>{% endif %}
                     TEXT,
                 context: [
-                    "campLeader" => $this->scene->templateConfig["campLeader"],
+                    "campLeader" => $event->scene->templateConfig["campLeader"],
                     "badGuy" => $battleState->badGuy,
                     "maxHealth" => $this->health->getMaxHealth(),
                     "textLost" => $battleState->badGuy->kwargs["textLost"] ?? null,
@@ -305,7 +316,7 @@ class TrainingTemplate implements SceneTemplateInterface
         ];
 
         $this->health->heal();
-        $this->setSeenMaster($this->stage->owner);
+        $this->setSeenMaster($event->character);
     }
 
     public function getSeenMaster(Character $character): bool
@@ -318,79 +329,81 @@ class TrainingTemplate implements SceneTemplateInterface
         $character->setProperty("lotgd2.trainingTemplate.seenMaster", $seenMaster);
     }
 
-    public function addDefaultActions(): void
+    public function addDefaultActions(Stage $stage, Scene $scene): void
     {
         $actionGroup = new ActionGroup(self::ActionGroupTraining, "Training");
         $actionGroup->addAction(new Action(
-            $this->scene,
+            $scene,
             title: "Question Master",
             parameters: ["op" => "ask"],
             reference: self::ActionQuestion,
         ));
         $actionGroup->addAction(new Action(
-            $this->scene,
+            $scene,
             title: "Challenge Master",
             parameters: ["op" => "challenge"],
             reference: self::ActionChallenge,
         ));
 
-        $this->stage->addActionGroup($actionGroup);
+        $stage->addActionGroup($actionGroup);
 
 
         if ($this->security->isGranted("ROLE_CHEATS_ENABLED")) {
             $cheatsGroup = new ActionGroup("lotgd2.actionGroup.fightTemplate.cheats", "Cheats");
             $cheatsGroup->setActions([
                 new Action(
-                    scene: $this->scene,
+                    scene: $scene,
                     title: "#! Unsee master",
                     parameters: ["op" => "cheat", "what" => "unseeMaster"],
                     reference: "lotgd2.action.fightTemplate.cheats.unseeMaster",
                 ),
                 new Action(
-                    scene: $this->scene,
+                    scene: $scene,
                     title: "#! Gain 1 level",
                     parameters: ["op" => "cheat", "what" => "levelUp"],
                     reference: "lotgd2.action.fightTemplate.cheats.levelUp",
                 ),
                 new Action(
-                    scene: $this->scene,
+                    scene: $scene,
                     title: "#! Set level to 15",
                     parameters: ["op" => "cheat", "what" => "level15"],
                     reference: "lotgd2.action.fightTemplate.cheats.level15",
                 ),
             ]);
 
-            $this->stage->addActionGroup($cheatsGroup);
+            $stage->addActionGroup($cheatsGroup);
         }
     }
 
     public function handleCheats(Character $character, string $cheat): void
     {
         if ($cheat === "unseeMaster") {
-            $this->setSeenMaster($character);
+            $this->setSeenMaster($character, false);
         } elseif ($cheat === "levelUp") {
-            $this->levelUp();
+            $this->levelUp($character);
         } elseif ($cheat === "level15") {
-            $this->levelUp(15);
+            $this->levelUp($character, 15);
         }
     }
 
     /**
+     * @param Character $character
+     * @param int|null $targetLevel
      * @return void
      */
-    public function levelUp(?int $targetLevel = null): void
+    public function levelUp(Character $character, ?int $targetLevel = null): void
     {
-        $oldCharacter = clone $this->character;
+        $oldCharacter = clone $character;
 
         if ($targetLevel === null) {
             $level = 1;
         } else {
-            $level = $targetLevel - $this->character->level;
+            $level = $targetLevel - $character->level;
         }
 
-        $this->character->level += $level;
-        $this->logger->debug("{$this->character}: Level increased to {$this->character->level}.");
-        $event = new CharacterChangeEvent($this->character, $oldCharacter);
+        $character->level += $level;
+        $this->logger->debug("{$character}: Level increased to {$character->level}.");
+        $event = new CharacterChangeEvent($character, $oldCharacter);
 
         $this->eventDispatcher->dispatch($event, self::OnCharacterLevelUp);
     }

--- a/tests/Game/Battle/BattleTest.php
+++ b/tests/Game/Battle/BattleTest.php
@@ -15,6 +15,7 @@ use LotGD2\Entity\Battle\FighterInterface;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Entity\Mapped\Scene;
 use LotGD2\Entity\Mapped\Stage;
+use LotGD2\Event\BattleNavigationChangeEvent;
 use LotGD2\Game\Battle\Battle;
 use LotGD2\Game\Battle\BattleEvent\BattleEventInterface;
 use LotGD2\Game\Battle\BattleEvent\CriticalHitEvent;
@@ -26,6 +27,9 @@ use LotGD2\Game\Handler\EquipmentHandler;
 use LotGD2\Game\Handler\HealthHandler;
 use LotGD2\Game\Handler\StatsHandler;
 use LotGD2\Game\Random\DiceBag;
+use LotGD2\Game\Scene\SceneRenderer;
+use LotGD2\Game\Stage\ActionService;
+use LotGD2\Repository\AttachmentRepository;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Depends;
@@ -58,6 +62,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[UsesClass(BattleMessage::class)]
 #[UsesClass(BattleRoundMessage::class)]
 #[UsesClass(DeathEvent::class)]
+#[UsesClass(BattleNavigationChangeEvent::class)]
 #[AllowMockObjectsWithoutExpectations]
 class BattleTest extends KernelTestCase
 {
@@ -68,8 +73,11 @@ class BattleTest extends KernelTestCase
     private NormalizerInterface&DenormalizerInterface $normalizer;
     private LoggerInterface&MockObject $logger;
     private BuffHandler&MockObject $buffHandler;
-    private Security&MockObject $security;
     private EventDispatcherInterface&MockObject $eventDispatcher;
+    private SceneRenderer&MockObject $sceneRenderer;
+    private ActionService&MockObject $actionService;
+    private AttachmentRepository&MockObject $attachmentRepository;
+    private DiceBag&MockObject $diceBag;
 
     public function setUp(): void
     {
@@ -82,19 +90,25 @@ class BattleTest extends KernelTestCase
         $this->character = new Character(name: "Test", level: 1);
         $this->turn = $this->createMock(BattleTurn::class);
         $this->buffHandler = $this->createMock(BuffHandler::class);
-        $this->security = $this->createMock(Security::class);
-        $this->security->expects($this->atLeast(0))->method("isGranted")->willReturn(false);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->sceneRenderer = $this->createMock(SceneRenderer::class);
+        $this->actionService = $this->createMock(ActionService::class);
+        $this->attachmentRepository = $this->createMock(AttachmentRepository::class);
+        $this->diceBag = $this->createMock(DiceBag::class);
         $stopWatch = $this->createStub(Stopwatch::class);
 
         $this->battle = new Battle(
             logger: $this->logger,
             stopWatch: $stopWatch,
             eventDispatcher: $this->eventDispatcher,
-            security: $this->security,
             normalizer: $this->normalizer,
             turn: $this->turn,
-            buffHandler: $this->buffHandler, character: $this->character,
+            sceneRenderer: $this->sceneRenderer,
+            actionService: $this->actionService,
+            attachmentRepository: $this->attachmentRepository,
+            diceBag: $this->diceBag,
+            buffHandler: $this->buffHandler,
+            character: $this->character,
         );
     }
 
@@ -118,6 +132,11 @@ class BattleTest extends KernelTestCase
             owner: $this->character,
             scene: $scene,
         );
+
+        $this->eventDispatcher->expects($this->once())->method('dispatch')->willReturnCallback(function (BattleNavigationChangeEvent $event, string $eventName) {
+            $this->assertSame(Battle::OnAddFightActions, $eventName);
+            return $event;
+        });
 
         $this->battle->addFightActions($stage, $scene, $battleState);
 
@@ -152,6 +171,11 @@ class BattleTest extends KernelTestCase
             scene: $scene,
         );
         $params = ["op" => "fight"];
+
+        $this->eventDispatcher->expects($this->once())->method('dispatch')->willReturnCallback(function (BattleNavigationChangeEvent $event, string $eventName) {
+            $this->assertSame(Battle::OnAddFightActions, $eventName);
+            return $event;
+        });
 
         $this->battle->addFightActions($stage, $scene, $battleState, $params);
 

--- a/tests/Game/Battle/BattleTest.php
+++ b/tests/Game/Battle/BattleTest.php
@@ -40,6 +40,8 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[CoversClass(Battle::class)]
 #[UsesClass(Character::class)]
@@ -67,6 +69,7 @@ class BattleTest extends KernelTestCase
     private LoggerInterface&MockObject $logger;
     private BuffHandler&MockObject $buffHandler;
     private Security&MockObject $security;
+    private EventDispatcherInterface&MockObject $eventDispatcher;
 
     public function setUp(): void
     {
@@ -81,10 +84,13 @@ class BattleTest extends KernelTestCase
         $this->buffHandler = $this->createMock(BuffHandler::class);
         $this->security = $this->createMock(Security::class);
         $this->security->expects($this->atLeast(0))->method("isGranted")->willReturn(false);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $stopWatch = $this->createStub(Stopwatch::class);
 
         $this->battle = new Battle(
             logger: $this->logger,
-            stopWatch: null,
+            stopWatch: $stopWatch,
+            eventDispatcher: $this->eventDispatcher,
             security: $this->security,
             normalizer: $this->normalizer,
             turn: $this->turn,

--- a/tests/Game/Scene/SceneTemplate/FightTemplateTest.php
+++ b/tests/Game/Scene/SceneTemplate/FightTemplateTest.php
@@ -354,15 +354,22 @@ class FightTemplateTest extends TestCase
                 ["how", null],
             ]);
 
-        $this->logger->expects($this->once())
+        $found = false;
+        $this->logger->expects($this->atLeastOnce())
             ->method('debug')
-            ->with('Called FightTemplate::onSceneChange, op=fight');
+            ->willReturnCallback(function (string $message, array $context) use (&$found) {
+                if ($message === 'Called FightTemplate::onSceneChange, op=fight') {
+                    $found = true;
+                }
+            });
 
         // Mock the fightAction method by expecting it to be called
         // Since fightAction is likely implemented in DefaultFightTrait, 
         // we just verify the method dispatch works correctly
         $this->fightTemplate->setSceneChangeParameter($stage, $action, $scene);
         $this->fightTemplate->onSceneChange();
+
+        $this->assertTrue($found);
     }
 
     public function testOnSceneChangeWithCheats(): void
@@ -650,7 +657,7 @@ class FightTemplateTest extends TestCase
                     $value[0]->id,
                 );
                 $this->assertSame(
-                    'You are too blind to see any monsters. Maybe prey to the gods and ask for why that is?',
+                    'You are too blind to see any monsters. Maybe pray to the gods and ask for why that is?',
                     $value[0]->text,
                 );
             });
@@ -726,7 +733,7 @@ class FightTemplateTest extends TestCase
             ->method('addActionGroup');
 
         $this->fightTemplate->setSceneChangeParameter($stage, $action, $scene);
-        $this->fightTemplate->addDefaultActions();
+        $this->fightTemplate->addDefaultActions($stage, $scene);
     }
 
     public function testAddDefaultActionsLevelOne(): void
@@ -773,7 +780,7 @@ class FightTemplateTest extends TestCase
             }));
 
         $this->fightTemplate->setSceneChangeParameter($stage, $action, $scene);
-        $this->fightTemplate->addDefaultActions();
+        $this->fightTemplate->addDefaultActions($stage, $scene);
     }
 
     public function testGetRandomLevelChangeReturnsValidRange(): void


### PR DESCRIPTION
`Battle::onBeforeSameSceneChange` listens to the new `GameLoop::OnBeforeSameSceneChange` (a `StageChangeEvent` emitted every time a scene changes internally, before standard rendering is applied). If a battleState is present in the action parameters, it takes over and stops propagation.
- Battle emits multiple events:
  - A new `Battle::OnFlightFlee` (`SimpleStageParameterEvent`) event emitted to check whether a character successfully flees or not. A default event listener is added, but can be high-jacked with higher priority that stops propagation.
  - A new `Battle::OnFlightFled` (`SimpleStageParameterEvent`) event emitted upon successfully fleeing
  - The OnSkillActivationEvent is now emitted by Battle, not by DefaultFight trait anymore. I think it fits better here, and separates responsibilities better
  - A new `Battle::OnFightEnds` (`SimpleStageParameterEvent`) event emitted one a battle reaches its conclusion.
  - DefaultFightTrait has an EventListener for onFightEnds and onFightFled that immediatly exit when their template does not match the scene. As it is a trait, every class using the trait adds another event listener and this is the only way to only call the truly responsible listener.
  - onFightWon / onFightLost can be overwritten by scene templates using the traits, same as before. Only important difference is that during the event, you cannot access character / stage / scene / action from the object, you must use the ones provided by the event.
- Some small typo fixes here and there
- Passes phpstan and phpunit
- God mode skill is now part of SpecialtyHandler