### PR TITLE
Adds Specialties to the Game

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
     "autoload": {
         "psr-4": {
             "LotGD2\\": "src/"
-        }
+        },
+        "files": ["src/functions.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,8 +18,9 @@ services:
         exclude:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
-            - '../src/Kernel.php'
             - '../src/Event/'
+            - '../src/Kernel.php'
+            - '../src/functions.php'
 
     Gglnx\TwigTryCatch\Extension\TryCatchExtension:
         tags: [twig.extension]

--- a/migrations/dev/Version20260428143409.php
+++ b/migrations/dev/Version20260428143409.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace DoctrineMigrations\Dev;
+
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260428143409 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds a table for specialties';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $specialtyTable = $schema->createTable("specialty");
+        $specialtyTable->addColumn("id", Types::INTEGER)->setAutoincrement(true)->setNotnull(true);
+        $specialtyTable->addColumn("name", Types::STRING)->setLength(255)->setNotnull(true);
+        $specialtyTable->addColumn("description", Types::TEXT)->setNotnull(true);
+        $specialtyTable->addColumn("selection_text", Types::TEXT)->setNotnull(true);
+        $specialtyTable->addColumn("class_name", Types::STRING)->setLength(255)->setNotnull(false);
+        $specialtyTable->addColumn("skills", Types::JSONB)->setNotnull(true);
+        $specialtyTable->addColumn("configuration", Types::JSONB)->setNotnull(true);
+
+        $specialtyTable->addPrimaryKeyConstraint(PrimaryKeyConstraint::editor()->setUnquotedColumnNames("id")->create());
+        $specialtyTable->addIndex(["name"], "IDX_E066A6EC5E237E06");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable("specialty");
+    }
+}

--- a/src/DataFixtures/SpecialtyFixtures.php
+++ b/src/DataFixtures/SpecialtyFixtures.php
@@ -1,0 +1,256 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use LotGD2\Entity\Battle\ProtoBuff;
+use LotGD2\Entity\Character\SpecialtySkill;
+use LotGD2\Entity\Mapped\Race;
+use LotGD2\Entity\Mapped\Specialty;
+use LotGD2\Game\Race\StandardRace;
+
+class SpecialtyFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $specialties = [
+            new Specialty(
+                name: "Dark Arts",
+                description: <<<TEXT
+                    Killing a lot of woodland creatures (Dark Arts)
+                    TEXT,
+                selectionText: <<<TXT
+                    Growing up, you recall killing many small woodland creatures, insisting that they were plotting 
+                    against you. Your parents, concerned that you had taken to killing the creatures barehanded, bought 
+                    you your very first pointy twig. It wasn't until your teenage years that you began performing dark 
+                    rituals with the creatures, disappearing into the forest for days on end, no one quite knowing where 
+                    those sounds came from.
+                    TXT,
+                className: null,
+                skills: [
+                    new SpecialtySkill(
+                        name: "Skeleton Crew",
+                        costs: 1,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.darkArts.1",
+                            name: "Skeleton Crew",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_ROUNDSTART,
+                            rounds: 5,
+                            startMessage: "You call on the spirits of the dead, and skeletal hands claw at {{ badGuy.name }} from beyond the grave.",
+                            endMessage: "Your skeleton minions crumble to dust",
+                            effectSuccessMessage: "An undead minion hits {{ badGuy.name }} for {{ damage }} damage.",
+                            noEffectMessage: "An undead minion tries to hit {{ badGuy.name }} but MISSES.",
+                            numberOfMinions: "character.level/3  + 1",
+                            minionMaxBadGuyDamage: "character.level/2 + 1",
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Voodoo",
+                        costs: 2,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.darkArts.2",
+                            name: "Voodoo",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_ROUNDSTART,
+                            rounds: 1,
+                            startMessage: "You pull out a tiny doll that looks like {{ badGuy.name }}.",
+                            effectSuccessMessage: "You thrust a pin into the {{ badGuy.name }} doll hurting it for {{ damage }} points!",
+                            numberOfMinions: 1,
+                            minionMinBadGuyDamage: "stats.attack * 1.5",
+                            minionMaxBadGuyDamage: "stats.attack * 3",
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Curse Spirit",
+                        costs: 3,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.darkArts.3",
+                            name: "Curse Spirit",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_DEFENSE_TURN,
+                            rounds: 5,
+                            startMessage: "You place a curse on {{ badGuy.name }}'s ancestors.",
+                            roundMessage: "{{ badGuy.name}} staggers under the weight of your curse, and deals only half damage.",
+                            endMessage: "Your curse has faded.",
+                            badGuyDamageModifier: 0.5,
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Wither Soul",
+                        costs: 5,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.darkArts.4",
+                            name: "Wither Soul",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_BOTH_TURNS,
+                            rounds: 5,
+                            startMessage: "You hold out your hand and {{ badGuy.name }} begins to bleed from their ears.",
+                            roundMessage: "{{ badGuy.name }} claws at their eyes, trying to release their own soul, and cannot attack or defend.",
+                            endMessage: "Your victim's soul has been restored.",
+                            badGuyDamageModifier: 0.,
+                            badGuyAttackModifier: 0.,
+                        ),
+                    ),
+                ],
+                configuration: [
+                ],
+            ),
+            new Specialty(
+                name: "Mystical Powers",
+                description: <<<TEXT
+                    Dabbling in mystical forces (Mystical Powers)
+                    TEXT,
+                selectionText: <<<TXT
+                    Growing up, you remember knowing there was more to the world than the physical, and what you could 
+                    place your hands on. You realized that your mind itself, with training, could be turned in to a 
+                    weapon. Over time, you began to control the thoughts of small creatures, commanding them to do your 
+                    bidding, and also to begin to tap in to the mystical force known as mana, which could be shaped in 
+                    to numerous elemental forms, fire, water, ice, earth, wind, and also used as a weapon against your foes.
+                    TXT,
+                className: null,
+                skills: [
+                    new SpecialtySkill(
+                        name: "Regeneration",
+                        costs: 1,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.mysticalPowers.1",
+                            name: "Regeneration",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_ROUNDSTART,
+                            rounds: 5,
+                            startMessage: "You begin to regenerate!",
+                            endMessage: "You have stopped regenerating.",
+                            effectSuccessMessage: "You regenerate for {{ damage }} health.",
+                            noEffectMessage: "You have no wounds to regenerate.",
+                            goodGuyRegeneration: "character.level",
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Earth Fist",
+                        costs: 2,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.mysticalPowers.2",
+                            name: "Earth Fist",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_ROUNDSTART,
+                            rounds: 5,
+                            startMessage: "{{ badGuy.name }} is clutched by a fist of earth and slammed to the ground!",
+                            endMessage: "The earthen fist crumbles to dust.",
+                            effectSuccessMessage: "A huge fist of earth pummels {{ badGuy.name }} for {{ damage }} points.",
+                            numberOfMinions: 1,
+                            minionMinBadGuyDamage: 1,
+                            minionMaxBadGuyDamage: "character.level * 3",
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Siphon Life",
+                        costs: 3,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.mysticalPowers.3",
+                            name: "Siphon Life",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_BOTH_TURNS,
+                            rounds: 5,
+                            startMessage: "Your weapon glows with an unearthly presence.",
+                            endMessage: "Your weapon's aura fades.",
+                            effectSuccessMessage: "You are healed for {{ damage }} health.",
+                            effectFailsMessage: "Your weapon wails as you deal no damage to your opponent.",
+                            noEffectMessage: "You feel a tingle as your weapon tries to heal your effectivly healthy body.",
+                            goodGuyLifeTap: 1.,
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Lightning Aura",
+                        costs: 5,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.mysticalPowers.4",
+                            name: "Lightning Aura",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_BOTH_TURNS,
+                            rounds: 5,
+                            startMessage: "Your skin sparkles as you assume an aura of lightning.",
+                            endMessage: "With a fizzle, your skin returns to normal.",
+                            effectSuccessMessage: "{{ badGuy.name }} recoils as lighning arcs out from your skin, hitting for {{ damage }} damage.",
+                            effectFailsMessage: "{{ badGuy.name }} is slightly singed by your lightning, but otherwise unharmed.",
+                            noEffectMessage: "{{ badGuy.name }} is slightly singed by your lightning, but otherwise unharmed.",
+                            goodGuyDamageReflection: 2.,
+                        ),
+                    ),
+                ],
+                configuration: [
+                ],
+            ),
+            new Specialty(
+                name: "Thievery",
+                description: <<<TEXT
+                    Stealing from the rich and giving to yourself (Thievery)
+                    TEXT,
+                selectionText: <<<TXT
+                    Growing up, you recall discovering that a casual bump in a crowded room could earn you the coin 
+                    purse of someone otherwise more fortunate than you.  You also discovered that the back side of your 
+                    enemies were considerably more prone to a narrow blade than the front side was to even a powerful weapon.
+                    TXT,
+                className: null,
+                skills: [
+                    new SpecialtySkill(
+                        name: "Insult",
+                        costs: 1,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.thievery.1",
+                            name: "Insult",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_DEFENSE_TURN,
+                            rounds: 5,
+                            startMessage: "You call {{ badGuy.name }} a bad name, making them cry.",
+                            roundMessage: "{{ badGuy.name }} feels dejected and cannot attack as well.",
+                            endMessage: "Your victim stops crying and wipes its nose.",
+                            badGuyDamageModifier: 0.5,
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Poison Blade",
+                        costs: 2,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.thievery.2",
+                            name: "Poison Blade",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_OFFENSE_TURN,
+                            rounds: 5,
+                            startMessage: "You apply some poison to your {{ goodGuy.weapon }} ",
+                            roundMessage: "Your attack is multiplied!",
+                            endMessage: "Your victim's blood has washed the poison from your blade.",
+                            goodGuyAttackModifier: 2.,
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Hidden Attack",
+                        costs: 3,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.thievery.3",
+                            name: "Hidden Attack",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_DEFENSE_TURN,
+                            rounds: 5,
+                            startMessage: "With the skill of an expert thief, you virtually dissapear, and attack {{ badGuy.name }} from a safer vantage point.",
+                            roundMessage: "{{ badGuy.name}} cannot locate you.",
+                            endMessage: "Your victim has located you.",
+                            badGuyAttackModifier: 0.,
+                        ),
+                    ),
+                    new SpecialtySkill(
+                        name: "Backstab",
+                        costs: 5,
+                        buff: new ProtoBuff(
+                            id: "lotgd2.specialties.thievery.4",
+                            name: "Backstab",
+                            activatesAt: ProtoBuff::ACTIVATES_ON_BOTH_TURNS,
+                            rounds: 5,
+                            startMessage: "Using your skills as a thief, dissapear behind {{ badGuy.name }} and slide a thin blade between its vertibrae!",
+                            roundMessage: "Your attack is multiplied, as is your defense!",
+                            endMessage: "Your victim won't be so likely to let you get behind it again!",
+                            goodGuyAttackModifier: 3.,
+                            goodGuyDefenseModifier: 3.,
+                        )
+                    ),
+                ],
+                configuration: [
+                ],
+            ),
+        ];
+
+        array_map(fn (Specialty $specialty) => $manager->persist($specialty), $specialties);
+        $manager->flush();
+    }
+}

--- a/src/Doctrine/ClassNameType.php
+++ b/src/Doctrine/ClassNameType.php
@@ -22,7 +22,9 @@ class ClassNameType extends StringType
      */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?string
     {
-        if (class_exists($value)) {
+        if ($value === null) {
+            return null;
+        } elseif (class_exists($value)) {
             return $value;
         } else {
             return null;

--- a/src/Entity/Battle/ProtoBuff.php
+++ b/src/Entity/Battle/ProtoBuff.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Entity\Battle;
+
+/**
+ * ProtoBuff is a variant of Buff that allows strings for most properties.
+ *
+ * To convert into a buff, it requires proper evaluation via the ExpressionService.
+ */
+class ProtoBuff
+{
+    const int ACTIVATES_ON_ROUNDSTART = 0b0001;
+    const int ACTIVATES_ON_ROUNDEND = 0b0010;
+    const int ACTIVATES_ON_OFFENSE_TURN = 0b0100;
+    const int ACTIVATES_ON_DEFENSE_TURN = 0b1000;
+    const int ACTIVATES_ON_BOTH_TURNS = 0b1100;
+    const int ACTIVATES_NEVER = 0b0000;
+    const int ACTIVATES_ANY = 0b1111;
+    const int INFINITE_ROUNDS = -1;
+
+    /**
+     * @param string $id
+     * @param string $name Name of the buff
+     * @param int $activatesAt At which part of the battle the buff gets activated
+     * @param int $rounds For how many rounds the buff stays. If == 0, the buff will expire. If < 0, the buff is permanent (unless expiresOnNewDay or expiresAfterBattle are turned on)
+     * @param string|null $startMessage Message displayed if the buff is activates
+     * @param string|null $roundMessage Message displayed if the buff is activate at the start of a round
+     * @param string|null $endMessage Message displayed if the buff expires
+     * @param string|null $effectSuccessMessage Message displayed if the buff's effect was successful
+     * @param string|null $effectFailsMessage Message displayed if the buff's effect failed
+     * @param string|null $noEffectMessage Message displayed if the buff has no effect
+     * @param string|null $newDayMessage Message displayed on a new day if the buff is still there
+     * @param bool $expiresOnNewDay True if the buff will be expired on a new day no matter how many rounds are left
+     * @param bool $expiresAfterBattle True if the buff will be expired on the end of a battle no matter how many rounds are left
+     * @param string|int $badGuyRegeneration Amount of health the badguy regenerates
+     * @param string|int $goodGuyRegeneration Amount of health the goodguy regenerates
+     * @param string|float $badGuyLifeTap Fraction of the damage caused to the badGuy that gets converted to health for the goodGuy
+     * @param string|float $goodGuyLifeTap Fraction of the damage caused to the goodGuy that gets converted to health for the badGuy
+     * @param string|float $badGuyDamageReflection Fraction of the damage caused to the badGuy that gets reflected to the goodGuy
+     * @param string|float $goodGuyDamageReflection Fraction of the damage caused to the goodGuy that gets reflected to the badGuy
+     * @param string|float $badGuyDamageModifier Effective damage done to the badGuy will be modified by this amount
+     * @param string|float $goodGuyDamageModifier Effective damage done to the goodGuy will be modified by this amount
+     * @param string|float $badGuyAttackModifier Modifies the badGuy's attack value before damage is calculated
+     * @param string|float $goodGuyAttackModifier Modifies the goodGuy's attack value before damage is calculcated
+     * @param string|float $badGuyDefenseModifier Modifies the badGuy's defense value before damage is calculcated
+     * @param string|float $goodGuyDefenseModifier Modifies the goodGuy's defense value before damage is calculcated
+     * @param string|bool $badGuyInvulnerable Set to true if the badGuy is completely invulnurable during the buff's duration
+     * @param string|bool $goodGuyInvulnerable Set to true if the goodGuy is completely invulnurable during the buff's duration
+     * @param string|int $numberOfMinions Number of minions that get summoned
+     * @param string|int $minionMinBadGuyDamage Minimum damage that a minion causes to the badGuy
+     * @param string|int $minionMaxBadGuyDamage Maximum damage that a minion causes to the badGuy. Uses pseudoBell to calculate the effective damage.
+     * @param string|int $minionMinGoodGuyDamage Minimum damage that a minion causes to the goodGuy
+     * @param string|int $minionMaxGoodGuyDamage Maximum damage that a minion causes to the goodGuy. Uses pseudoBell to calculate the effective damage.
+     */
+    public function __construct(
+        protected(set) string $id,
+        protected(set) string $name,
+        protected(set) int $activatesAt,
+        protected(set) int $rounds,
+        protected(set) ?string $startMessage = null,
+        protected(set) ?string $roundMessage = null,
+        protected(set) ?string $endMessage = null,
+        protected(set) ?string $effectSuccessMessage = null,
+        protected(set) ?string $effectFailsMessage = null,
+        protected(set) ?string $noEffectMessage = null,
+        protected(set) ?string $newDayMessage = null,
+        protected(set) bool $expiresOnNewDay = true,
+        protected(set) bool $expiresAfterBattle = false,
+        protected(set) string|int $badGuyRegeneration = 0,
+        protected(set) string|int $goodGuyRegeneration = 0,
+        protected(set) string|float $badGuyLifeTap = 0.,
+        protected(set) string|float $goodGuyLifeTap = 0.,
+        protected(set) string|float $badGuyDamageReflection = 0.,
+        protected(set) string|float $goodGuyDamageReflection = 0.,
+        protected(set) string|float $badGuyDamageModifier = 1.,
+        protected(set) string|float $goodGuyDamageModifier = 1.,
+        protected(set) string|float $badGuyAttackModifier = 1.,
+        protected(set) string|float $goodGuyAttackModifier = 1.,
+        protected(set) string|float $badGuyDefenseModifier = 1.,
+        protected(set) string|float $goodGuyDefenseModifier = 1.,
+        protected(set) string|bool $badGuyInvulnerable = false,
+        protected(set) string|bool $goodGuyInvulnerable = false,
+        protected(set) string|int $numberOfMinions = 0,
+        protected(set) string|int $minionMinBadGuyDamage = 0,
+        protected(set) string|int $minionMaxBadGuyDamage = 0,
+        protected(set) string|int $minionMinGoodGuyDamage = 0,
+        protected(set) string|int $minionMaxGoodGuyDamage = 0,
+    ) {
+
+    }
+}

--- a/src/Entity/Character/CharacterSpecialty.php
+++ b/src/Entity/Character/CharacterSpecialty.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Entity\Character;
+
+use LotGD2\Entity\Mapped\Specialty;
+use Stringable;
+
+class CharacterSpecialty implements Stringable
+{
+    public ?int $id;
+    public ?string $name;
+    /** @var null|class-string  */
+    public ?string $className;
+    /** @var array<string, mixed>  */
+    public array $configuration;
+
+    public int $level = 0;
+    public int $uses = 0;
+
+    /**
+     * Represents a selected specialty on a character.
+     *
+     * Constructor parameter is optional to permit deserialization from an array.
+     *
+     * @param Specialty|null $specialty Use parameter to create a pre-filled version created from a specialty.
+     */
+    public function __construct(
+        ?Specialty $specialty = null,
+    ) {
+        if ($specialty !== null) {
+            $this->id = $specialty->id;
+            $this->name = $specialty->name;
+            $this->className = $specialty->className;
+            $this->configuration = $specialty->configuration;
+        }
+    }
+
+    public function __toString(): string
+    {
+        return "<CharacterSpecialty#{$this->id} {$this->name}>";
+    }
+}

--- a/src/Entity/Character/SpecialtySkill.php
+++ b/src/Entity/Character/SpecialtySkill.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Entity\Character;
+
+use LotGD2\Entity\Battle\ProtoBuff;
+
+class SpecialtySkill
+{
+    public function __construct(
+        protected(set) string $name,
+        protected(set) int $costs,
+        protected(set) ProtoBuff $buff,
+    ) {
+
+    }
+}

--- a/src/Entity/Mapped/Specialty.php
+++ b/src/Entity/Mapped/Specialty.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Entity\Mapped;
+
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Dunglas\DoctrineJsonOdm\Type\JsonbDocumentType;
+use Dunglas\DoctrineJsonOdm\Type\JsonDocumentType;
+use LotGD2\Doctrine\ClassNameType;
+use LotGD2\Entity\Battle\ProtoBuff;
+use LotGD2\Entity\Character\SpecialtySkill;
+use LotGD2\Game\Race\RaceInterface;
+use LotGD2\Repository\SpecialtyRepository;
+use Stringable;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @template TConfig of array<string, mixed> = array<string, mixed>
+ */
+#[ORM\Entity(repositoryClass: SpecialtyRepository::class)]
+#[ORM\Index(fields: ["name"])]
+class Specialty implements Stringable
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private(set) ?int $id = null;
+
+    /**
+     * @param string|null $name
+     * @param string|null $description
+     * @param string|null $selectionText
+     * @param null|class-string<RaceInterface<TConfig>> $className
+     * @param array $configuration
+     * @param array $skills
+     */
+    public function __construct(
+        #[ORM\Column(length: 255)]
+        #[Assert\NotBlank()]
+        public ?string $name = null {
+            get => $this->name;
+            set => $value;
+        },
+
+        #[ORM\Column(type: Types::TEXT)]
+        #[Assert\NotBlank()]
+        public ?string $description = null {
+            get => $this->description;
+            set => $value;
+        },
+
+        #[ORM\Column(type: Types::TEXT)]
+        #[Assert\NotBlank()]
+        public ?string $selectionText = null {
+            get => $this->selectionText;
+            set => $value;
+        },
+
+        #[ORM\Column(type: ClassNameType::NAME, length: 255, nullable: true)]
+        #[Assert\NotBlank()]
+        public ?string $className = null {
+            get => $this->className;
+            set => $value;
+        },
+
+        /**
+         * @var list<SpecialtySkill>
+         */
+        #[ORM\Column(type: JsonbDocumentType::NAME)]
+        #[Assert\NotBlank()]
+        public array $skills = [] {
+            get => $this->skills;
+            set => $value;
+        },
+
+        /**
+         * @var TConfig
+         */
+        #[ORM\Column(type: Types::JSONB)]
+        #[Assert\NotBlank()]
+        public array $configuration = [] {
+            get => $this->configuration;
+            set => $value;
+        },
+    ) {
+
+    }
+
+    public function __toString(): string
+    {
+        return "<Speciality#{$this->id} {$this->name}>";
+    }
+}

--- a/src/Event/BattleSkillActivationEvent.php
+++ b/src/Event/BattleSkillActivationEvent.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 namespace LotGD2\Event;
+use LotGD2\Entity\Action;
 use LotGD2\Entity\Mapped\Character;
 use LotGD2\Game\Handler\BuffHandler;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -12,6 +13,7 @@ class BattleSkillActivationEvent extends Event
         public readonly Character $character,
         public readonly BuffHandler $buff,
         public readonly string $skillName,
+        public readonly Action $action,
     ) {
     }
 }

--- a/src/Game/Battle/Battle.php
+++ b/src/Game/Battle/Battle.php
@@ -328,7 +328,7 @@ class Battle
         if ($how === self::SkillFightActionParamValue) {
             $skill = $event->action->getParameter(self::SkillActionParam);
 
-            $battleSkillActivationEvent = new BattleSkillActivationEvent($event->character, $this->buffHandler, $skill);
+            $battleSkillActivationEvent = new BattleSkillActivationEvent($event->character, $this->buffHandler, $skill, $event->action);
             $this->eventDispatcher->dispatch($battleSkillActivationEvent, self::OnSkillActivationEvent);
         }
 

--- a/src/Game/Battle/Battle.php
+++ b/src/Game/Battle/Battle.php
@@ -186,7 +186,7 @@ class Battle
         $badGuyBuffStartEvents = $badGuyBuffs->activate(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->badGuy, $battleState->goodGuy);
 
         $goodGuyRoundStartBuffEvents = $goodGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->goodGuy, $battleState->badGuy);
-        $badGuyRoundStartBuffEvents = $goodGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->badGuy, $battleState->goodGuy);
+        $badGuyRoundStartBuffEvents = $badGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->badGuy, $battleState->goodGuy);
 
         [$offenseTurn, $defenseTurn] = $this->turn->getHalfTurns($battleState, $goodGuyBuffs, $badGuyBuffs);
 
@@ -201,7 +201,7 @@ class Battle
         $badGuyBuffEndEvents = $badGuyBuffs->activate(Buff::ACTIVATES_ON_ROUNDEND, $battleState->badGuy, $battleState->goodGuy);
 
         $goodGuyRoundEndBuffEvents = $goodGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDEND, $battleState->goodGuy, $battleState->badGuy);
-        $badGuyRoundEndBuffEvents = $goodGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDEND, $battleState->badGuy, $battleState->goodGuy);
+        $badGuyRoundEndBuffEvents = $badGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDEND, $battleState->badGuy, $battleState->goodGuy);
 
         // Expire buffs if necessary
         $goodGuyExpiredBuffEvents = $goodGuyBuffs->expireOneRound($battleState->goodGuy, $battleState->badGuy);

--- a/src/Game/Battle/Battle.php
+++ b/src/Game/Battle/Battle.php
@@ -185,6 +185,9 @@ class Battle
         $goodGuyBuffStartEvents = $goodGuyBuffs->activate(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->goodGuy, $battleState->badGuy);
         $badGuyBuffStartEvents = $badGuyBuffs->activate(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->badGuy, $battleState->goodGuy);
 
+        $goodGuyRoundStartBuffEvents = $goodGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->goodGuy, $battleState->badGuy);
+        $badGuyRoundStartBuffEvents = $goodGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDSTART, $battleState->badGuy, $battleState->goodGuy);
+
         [$offenseTurn, $defenseTurn] = $this->turn->getHalfTurns($battleState, $goodGuyBuffs, $badGuyBuffs);
 
         // Only add offence turns if it's part of the current round
@@ -197,6 +200,9 @@ class Battle
         $goodGuyBuffEndEvents = $goodGuyBuffs->activate(Buff::ACTIVATES_ON_ROUNDEND, $battleState->goodGuy, $battleState->badGuy);
         $badGuyBuffEndEvents = $badGuyBuffs->activate(Buff::ACTIVATES_ON_ROUNDEND, $battleState->badGuy, $battleState->goodGuy);
 
+        $goodGuyRoundEndBuffEvents = $goodGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDEND, $battleState->goodGuy, $battleState->badGuy);
+        $badGuyRoundEndBuffEvents = $goodGuyBuffs->processDirectBuffs(Buff::ACTIVATES_ON_ROUNDEND, $battleState->badGuy, $battleState->goodGuy);
+
         // Expire buffs if necessary
         $goodGuyExpiredBuffEvents = $goodGuyBuffs->expireOneRound($battleState->goodGuy, $battleState->badGuy);
         $badGuyExpiredBuffEvents = $badGuyBuffs->expireOneRound($battleState->badGuy, $battleState->goodGuy);
@@ -204,11 +210,15 @@ class Battle
         // Process events
         $events = new ArrayCollection([
             ... $goodGuyBuffStartEvents,
+            ... $goodGuyRoundStartBuffEvents,
             ... $badGuyBuffStartEvents,
+            ... $badGuyRoundStartBuffEvents,
             ... $offenseTurnEvents,
             ... $defenseTurnEvents,
             ... $goodGuyBuffEndEvents,
+            ... $goodGuyRoundEndBuffEvents,
             ... $badGuyBuffEndEvents,
+            ... $badGuyRoundEndBuffEvents,
             ... $goodGuyExpiredBuffEvents,
             ... $badGuyExpiredBuffEvents,
         ]);

--- a/src/Game/ExpressionService.php
+++ b/src/Game/ExpressionService.php
@@ -14,6 +14,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\Parser;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
 
+
 class ExpressionService
 {
     public function __construct(
@@ -27,10 +28,10 @@ class ExpressionService
 
     }
 
-    public function evaluate(?string $expression): bool
+    public function evaluate(?string $expression): mixed
     {
         if ($expression === null || strlen($expression) === 0) {
-            return true;
+            return null;
         }
 
         $expressionLanguage = new ExpressionLanguage();
@@ -46,6 +47,8 @@ class ExpressionService
             "stats" => (object)[
                 "experience" => $this->stats->getExperience(),
                 "required" => $this->stats->getRequiredExperience(),
+                "attack" => $this->stats->getTotalAttack(),
+                "defense" => $this->stats->getTotalDefense(),
             ],
             "gold" => $this->gold->getGold(null),
             "equipment" => (object)[
@@ -58,11 +61,44 @@ class ExpressionService
 
         try {
             $expressionLanguage->lint($expression, $names, $flags);
-            return (bool)$expressionLanguage->evaluate($expression, $names);
+            return $expressionLanguage->evaluate($expression, $names);
         } catch (SyntaxError $e) {
             // Allow connection to be made if expression contains an error
             $this->logger->warning("Expression was faulty: {$expression}. {$e->getMessage()}");
-            return true;
+            return null;
+        }
+    }
+
+    public function evaluateBoolean(?string $expression, $default = true): bool
+    {
+        $value = $this->evaluate($expression);
+
+        if ($value === null) {
+            return $default;
+        } else {
+            return (bool)$value;
+        }
+    }
+
+    public function evaluateInteger(?string $expression, $default = 0): int
+    {
+        $value = $this->evaluate($expression);
+
+        if ($value === null) {
+            return $default;
+        } else {
+            return (int)round($value);
+        }
+    }
+
+    public function evaluateFloat(?string $expression, $default = 1.): float
+    {
+        $value = $this->evaluate($expression);
+
+        if ($value === null) {
+            return $default;
+        } else {
+            return (float)$value;
         }
     }
 }

--- a/src/Game/Handler/BuffHandler.php
+++ b/src/Game/Handler/BuffHandler.php
@@ -6,7 +6,9 @@ namespace LotGD2\Game\Handler;
 use LotGD2\Entity\Battle\Buff;
 use LotGD2\Entity\Battle\BuffList;
 use LotGD2\Entity\Battle\FighterInterface;
+use LotGD2\Entity\Battle\ProtoBuff;
 use LotGD2\Entity\Mapped\Character;
+use LotGD2\Game\ExpressionService;
 use LotGD2\Game\Random\DiceBag;
 use LotGD2\Game\Random\DiceBagInterface;
 use Psr\Log\LoggerInterface;
@@ -20,7 +22,6 @@ class BuffHandler
         private ?LoggerInterface $logger = null,
         private ?DiceBagInterface $diceBag = null,
     ) {
-
     }
 
     public function getBuffs(Character|FighterInterface $fighter): BuffList
@@ -64,5 +65,56 @@ class BuffHandler
         } else {
             $fighter->kwargs[self::BuffPropertyName][] = $buff;
         }
+    }
+
+    public function addBuffFromPrototype(Character $character, ProtoBuff $protoBuff): void
+    {
+        $equipmentHandler = new EquipmentHandler($this->logger, $character);
+        $expressionService = new ExpressionService(
+            $this->logger,
+            $character,
+            health: new HealthHandler($this->logger, $character),
+            stats: new StatsHandler($this->logger, $equipmentHandler, $character),
+            gold: new GoldHandler($this->logger, $character),
+            equipment: $equipmentHandler,
+        );
+
+        $buff = new Buff(
+            id: $protoBuff->id,
+            name: $protoBuff->name,
+            activatesAt: $protoBuff->activatesAt,
+            rounds: $protoBuff->rounds,
+            startMessage: $protoBuff->startMessage,
+            roundMessage: $protoBuff->roundMessage,
+            endMessage: $protoBuff->endMessage,
+            effectSuccessMessage: $protoBuff->effectSuccessMessage,
+            effectFailsMessage: $protoBuff->effectFailsMessage,
+            noEffectMessage: $protoBuff->noEffectMessage,
+            newDayMessage: $protoBuff->newDayMessage,
+            expiresOnNewDay: $protoBuff->expiresOnNewDay,
+            expiresAfterBattle: $protoBuff->expiresAfterBattle,
+            badGuyRegeneration: is_string($protoBuff->badGuyRegeneration) ? $expressionService->evaluateInteger($protoBuff->badGuyRegeneration) : $protoBuff->badGuyRegeneration,
+            goodGuyRegeneration: is_string($protoBuff->goodGuyRegeneration) ? $expressionService->evaluateInteger($protoBuff->goodGuyRegeneration) : $protoBuff->goodGuyRegeneration,
+            badGuyLifeTap: is_string($protoBuff->badGuyLifeTap) ? $expressionService->evaluateFloat($protoBuff->badGuyLifeTap, 0) : $protoBuff->badGuyLifeTap,
+            goodGuyLifeTap: is_string($protoBuff->goodGuyLifeTap) ? $expressionService->evaluateFloat($protoBuff->goodGuyLifeTap, 0) : $protoBuff->goodGuyLifeTap,
+            badGuyDamageReflection: is_string($protoBuff->badGuyDamageReflection) ? $expressionService->evaluateFloat($protoBuff->badGuyDamageReflection, 0) : $protoBuff->badGuyDamageReflection,
+            goodGuyDamageReflection: is_string($protoBuff->goodGuyDamageReflection) ? $expressionService->evaluateFloat($protoBuff->goodGuyDamageReflection, 0) : $protoBuff->goodGuyDamageReflection,
+            badGuyDamageModifier: is_string($protoBuff->badGuyDamageModifier) ? $expressionService->evaluateFloat($protoBuff->badGuyDamageModifier, 1) : $protoBuff->badGuyDamageModifier,
+            goodGuyDamageModifier: is_string($protoBuff->goodGuyDamageModifier) ? $expressionService->evaluateFloat($protoBuff->goodGuyDamageModifier, 1) : $protoBuff->goodGuyDamageModifier,
+            badGuyAttackModifier: is_string($protoBuff->badGuyAttackModifier) ? $expressionService->evaluateFloat($protoBuff->badGuyAttackModifier, 1) : $protoBuff->badGuyAttackModifier,
+            goodGuyAttackModifier: is_string($protoBuff->goodGuyAttackModifier) ? $expressionService->evaluateFloat($protoBuff->goodGuyAttackModifier, 1) : $protoBuff->goodGuyAttackModifier,
+            badGuyDefenseModifier: is_string($protoBuff->badGuyDefenseModifier) ? $expressionService->evaluateFloat($protoBuff->badGuyDefenseModifier, 1) : $protoBuff->badGuyDefenseModifier,
+            goodGuyDefenseModifier: is_string($protoBuff->goodGuyDefenseModifier) ? $expressionService->evaluateFloat($protoBuff->goodGuyDefenseModifier, 1) : $protoBuff->goodGuyDefenseModifier,
+            badGuyInvulnerable: is_string($protoBuff->badGuyInvulnerable) ? $expressionService->evaluateBoolean($protoBuff->badGuyInvulnerable, false) : $protoBuff->badGuyInvulnerable,
+            goodGuyInvulnerable: is_string($protoBuff->goodGuyInvulnerable) ? $expressionService->evaluateBoolean($protoBuff->goodGuyInvulnerable, false) : $protoBuff->goodGuyInvulnerable,
+            numberOfMinions: is_string($protoBuff->numberOfMinions) ?  $expressionService->evaluateInteger($protoBuff->numberOfMinions, 0) : $protoBuff->numberOfMinions,
+            minionMinBadGuyDamage: is_string($protoBuff->minionMinBadGuyDamage) ? $expressionService->evaluateInteger($protoBuff->minionMinBadGuyDamage, 0) : $protoBuff->minionMinBadGuyDamage,
+            minionMaxBadGuyDamage: is_string($protoBuff->minionMaxBadGuyDamage) ? $expressionService->evaluateInteger($protoBuff->minionMaxBadGuyDamage, 0) : $protoBuff->minionMaxBadGuyDamage,
+            minionMinGoodGuyDamage: is_string($protoBuff->minionMinGoodGuyDamage) ? $expressionService->evaluateInteger($protoBuff->minionMinGoodGuyDamage, 0) : $protoBuff->minionMinGoodGuyDamage,
+            minionMaxGoodGuyDamage: is_string($protoBuff->minionMaxGoodGuyDamage) ? $expressionService->evaluateInteger($protoBuff->minionMaxGoodGuyDamage, 0) : $protoBuff->minionMaxGoodGuyDamage,
+        );
+
+
+        $this->addBuff($character, $buff);
     }
 }

--- a/src/Game/Handler/BuffHandler.php
+++ b/src/Game/Handler/BuffHandler.php
@@ -114,6 +114,10 @@ class BuffHandler
             minionMaxGoodGuyDamage: is_string($protoBuff->minionMaxGoodGuyDamage) ? $expressionService->evaluateInteger($protoBuff->minionMaxGoodGuyDamage, 0) : $protoBuff->minionMaxGoodGuyDamage,
         );
 
+        $this->logger->debug("{$character}: Adds a buff from a proto buff", context: [
+            "protoBuff" => $protoBuff,
+            "buff" => $buff,
+        ]);
 
         $this->addBuff($character, $buff);
     }

--- a/src/Game/Handler/SpecialtyHandler.php
+++ b/src/Game/Handler/SpecialtyHandler.php
@@ -6,29 +6,433 @@ namespace LotGD2\Game\Handler;
 use LotGD2\Entity\Action;
 use LotGD2\Entity\ActionGroup;
 use LotGD2\Entity\Battle\Buff;
+use LotGD2\Entity\Character\CharacterSpecialty;
+use LotGD2\Entity\Mapped\Character;
+use LotGD2\Entity\Mapped\Specialty;
+use LotGD2\Entity\Paragraph;
 use LotGD2\Event\BattleNavigationChangeEvent;
 use LotGD2\Event\BattleSkillActivationEvent;
+use LotGD2\Event\StageChangeEvent;
 use LotGD2\Game\Battle\Battle;
+use LotGD2\Game\GameTime\NewDay;
 use LotGD2\Game\Random\DiceBagAwareInterface;
 use LotGD2\Game\Random\DiceBagAwareTrait;
-use LotGD2\Game\Random\DiceBagInterface;
-use LotGD2\Game\Scene\SceneTemplate\DefaultFightTrait;
 use LotGD2\Game\Scene\SceneTemplate\FightTemplate;
+use LotGD2\Repository\SpecialtyRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Stopwatch\Stopwatch;
+use function LotGD2\array_filter_class;
 
 class SpecialtyHandler implements DiceBagAwareInterface
 {
     use DiceBagAwareTrait;
 
     const string ActionGodMode = "lotgd2.action.SpecialtyHandler.godMode";
+    const string SpecialtyProperty = "specialties";
+    const string MainSpecialtyProperty = "main_specialty";
 
     public function __construct(
         private LoggerInterface $logger,
         private Security $security,
+        private readonly Stopwatch $stopWatch,
+        private readonly SpecialtyRepository $specialtyRepository,
     ) {
 
+    }
+
+    /**
+     * Returns the Character's CharacterSpecialty with levels and uses
+     * @param Character $character
+     * @return CharacterSpecialty|null
+     */
+    public function getMainCharacterSpecialty(Character $character): ?CharacterSpecialty
+    {
+        $id = $character->getProperty(self::MainSpecialtyProperty, null);
+
+        if ($id === null) {
+            return null;
+        }
+
+        $specialties = $this->getSpecialties($character);
+
+        if (!isset($specialties[$id])) {
+            return null;
+        }
+
+        $characterSpecialty = $specialties[$id];
+
+        if ($characterSpecialty instanceof CharacterSpecialty) {
+            return $characterSpecialty;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the Character's selected Specialty.
+     * @param Character $character
+     * @return Specialty|null
+     */
+    public function getMainSpecialty(Character $character): ?Specialty
+    {
+        $id = $character->getProperty(self::MainSpecialtyProperty, null);
+
+        if ($id === null) {
+            return null;
+        }
+
+        $specialtyEntity = $this->specialtyRepository->find($id);
+
+        if ($specialtyEntity === null) {
+            return null;
+        }
+
+        return $specialtyEntity;
+    }
+
+    /**
+     * Sets the Character's main Specialty
+     * @param Character $character
+     * @param Specialty $specialty
+     * @return void
+     */
+    public function setMainSpecialty(Character $character, Specialty $specialty): void
+    {
+        $specialties = $this->getSpecialties($character);
+
+        if (!isset($specialties[$specialty->id])) {
+            $specialties[$specialty->id] = new CharacterSpecialty($specialty);
+        }
+
+        $character->setProperty(self::MainSpecialtyProperty, $specialty->id);
+        $character->setProperty(self::SpecialtyProperty, $specialties);
+    }
+
+    /**
+     * Returns true of the character has a main Specialty.
+     *
+     * @param Character $character
+     * @param Specialty|null $specialty
+     * @return bool
+     */
+    public function hasMainSpecialty(Character $character, ?Specialty $specialty = null): bool
+    {
+        $id = $character->getProperty(self::MainSpecialtyProperty, null);
+
+        if ($specialty === null) {
+            if ($id === null) {
+                return false;
+            }
+
+            $specialtyEntity = $this->specialtyRepository->find($id);
+            if ($specialtyEntity === null) {
+                $this->logger->warning("{$character} has a Specialty with id {$id} that cannot be found in the database.");
+                return false;
+            } else {
+                return true;
+            }
+        } else {
+            return $id !== null && $id === $specialty->id;
+        }
+    }
+
+    /**
+     * Returns a given specialty for a character or null if he doesn't have it yet.
+     * @param Character $character
+     * @param Specialty|null $specialty
+     * @return CharacterSpecialty|null
+     */
+    public function getSpecialty(Character $character, ?Specialty $specialty = null): ?CharacterSpecialty
+    {
+        if ($specialty === null) {
+            return null;
+        }
+
+        $specialties = $this->getSpecialties($character);
+        if (!isset($specialties[$specialty->id])) {
+            return null;
+        } else {
+            return $specialties[$specialty->id];
+        }
+    }
+
+    /**
+     * @param Character $character
+     * @return list<CharacterSpecialty>
+     */
+    public function getSpecialties(Character $character): array
+    {
+        $specialties = $character->getProperty(self::SpecialtyProperty, []);
+        return array_filter_class($specialties, CharacterSpecialty::class);
+    }
+
+    /**
+     * Listens to the new day and refreshes specialty uses of all specialties given to a user.
+     * @param StageChangeEvent $event
+     * @return void
+     */
+    #[AsEventListener(event: NewDay::OnNewDayAfter, priority: -10)]
+    public function onNewDayAfterEvent(StageChangeEvent $event): void
+    {
+        $character = $event->character;
+        $specialties = $this->getSpecialties($character);
+        $mainSpecialty = $this->getMainCharacterSpecialty($character);
+
+        // Add somewhere a setting for these
+        $usesPerLevel = 3;
+        $extraUsesOnMain = 1;
+
+        foreach ($specialties as $specialty) {
+            $isMainSpecialty = $specialty === $mainSpecialty;
+
+            // Reset first to 0
+            $specialty->uses = 0;
+
+            // Add uses-per-level
+            $uses = intdiv($specialty->level, $usesPerLevel);
+            $specialty->uses += $uses;
+
+            if ($isMainSpecialty) {
+                $specialty->uses += $extraUsesOnMain;
+            }
+
+            $this->logger->debug("{$character} receives {$specialty->uses} ({$uses} for the level)", context: [
+                "specialty" => $specialty,
+                "isMainSpecialty" => $isMainSpecialty,
+                "usesPerLevel" => $uses,
+                "extraUsesOnMain" => $extraUsesOnMain,
+            ]);
+
+            if ($isMainSpecialty) {
+                $event->stage->addParagraph(new Paragraph(
+                    "lotgd2.paragraph.StandardRace.onNewDay",
+                    text: <<<TXT
+                    For being interested in {{ specialty }}, you receive {{ extraUsesOnMain }} extra use for today.
+                    TXT,
+                    context: [
+                        "specialty" => $specialty->name,
+                        "extraUsesOnMain" => $extraUsesOnMain,
+                    ],
+                ));
+            }
+
+            // No message for side specialties
+        }
+    }
+
+    /**
+     * Listens to the OnNewDayBefore event and permits the character to select a specialty
+     * @param StageChangeEvent $event
+     * @return void
+     */
+    #[AsEventListener(event: NewDay::OnNewDayBefore, priority: 80)]
+    public function onNewDayEvent(StageChangeEvent $event): void
+    {
+        $this->stopWatch->start("lotgd2.Specialty.onNewDay", "lotgd");
+
+        $character = $event->character;
+        $stop = false;
+
+        if (isset($event->action->parameters["specialty"])) {
+            $stop = $this->doSpecialtySelection($event);
+        }
+
+        if ($this->hasMainSpecialty($character) === false) {
+            $stop = $this->showSpecialtySelection($event);
+        }
+
+        if ($stop) {
+            $event->setStopRender();
+        }
+
+        $this->stopWatch->stop("lotgd2.Specialty.onNewDay");
+    }
+
+    /**
+     * Selects the specialty and sets the character's property to it.
+     *
+     * If the specialty 'disappears' between selections, it will return false and the specialty selection screen is displayed
+     *  again.
+     * @param StageChangeEvent $event
+     * @return bool
+     */
+    public function doSpecialtySelection(StageChangeEvent $event): bool
+    {
+        $specialtyId = $event->action->parameters["specialty"];
+        $specialty = $this->specialtyRepository->find($specialtyId);
+
+        if ($specialty instanceof Specialty === false) {
+            // Specialty disappeared, or the selection was faulty, let continue to the character screen
+            return false;
+        }
+
+        $event->stage->title = "Childhood memories";
+        $event->stage->clearParagraphs();
+        $event->stage->addParagraph(new Paragraph(
+            id: "lotdg2.paragraph.Specialty.onSpecialtySelection",
+            text: $specialty->selectionText,
+        ));
+
+        $this->setMainSpecialty($event->character, $specialty);
+        $event->addAction(ActionGroup::EMPTY, new Action(title: "Continue"));
+
+        return true;
+    }
+
+    /**
+     * Adds all specialties with a short description to the stage's description and adds for each one an action to let the
+     *  character choose.
+     *
+     * If there are no specialties available, the event will be skipped.
+     * @param StageChangeEvent $event
+     * @return bool
+     */
+    public function showSpecialtySelection(StageChangeEvent $event): bool
+    {
+        $specialties = $this->specialtyRepository->findAll();
+
+        if (count($specialties) === 0) {
+            // If there are no specialties to choose from, continue and skip this event
+            $this->logger->info("There are no specialties available. Skipping specialty selection.");
+            return false;
+        }
+
+        $event->stage->clear();
+        $event->stage->title = "Childhood memories";
+        $event->stage->addParagraph(new Paragraph(
+                id: "lotdg2.paragraph.Specialty.generic",
+                text: "Growing up as a child, you remember ...")
+        );
+
+        $actionGroup = new ActionGroup(
+            id: "lotgd2.actionGroup.Specialty",
+            title: "Pick one",
+        );
+
+        $event->stage->addActionGroup($actionGroup);
+
+        foreach ($specialties as $specialty) {
+            $event->stage->addParagraph(new Paragraph(
+                id: "lotgd2.paragraph.Specialty.entry{$specialty->id}",
+                text: $specialty->description
+            ));
+
+            $event->addAction($actionGroup, new Action(
+                title: $specialty->name,
+                parameters: [
+                    "specialty" => $specialty->id,
+                ],
+                reference: "lotgd2.action.Specialty.entry{$specialty->id}"
+            ));
+        }
+
+        return true;
+    }
+
+    #[AsEventListener(Battle::OnAddFightActions)]
+    public function onBattleNavigationAddSkills(BattleNavigationChangeEvent $event): void
+    {
+        $character = $event->character;
+        $specialties = $this->getSpecialties($character);
+
+        foreach ($specialties as $specialty) {
+            if ($specialty->uses <= 0) {
+                // Skil if there are no uses available
+                continue;
+            }
+
+            // Separate query for each specialty is okay, because that is usually just 1
+            $specialtyEntity = $this->specialtyRepository->find($specialty->id);
+            $specialtySkills = $specialtyEntity->skills;
+
+            $specialtyActionGroup = new ActionGroup(
+                id: "lotgd2.actionGroup.Specialty.{$specialty->id}",
+                title: "{$specialty->name} (Uses: {$specialty->uses})",
+                weight: 100,
+            );
+
+            $addedSkillCount = 0;
+            foreach ($specialtySkills as $key => $specialtySkill) {
+                if ($specialtySkill->costs > $specialty->uses) {
+                    // Do not add skill if there are not enough
+                    continue;
+                }
+
+                $specialtyActionGroup->addAction($event->getAction(
+                    title: $specialtySkill->name . " (Costs: {$specialtySkill->costs})",
+                    reference: "lotgd2.action.Specialty.{$specialty->id}.{$key}",
+                    parameters: [
+                        "how" => "skill",
+                        "skill" => "specialty",
+                        "specialty" => $specialty->id,
+                        "specialty_skill" => $key,
+                    ]
+                ));
+
+                $addedSkillCount++;
+            }
+
+            if ($addedSkillCount > 0) {
+                $event->addActionGroup($specialtyActionGroup);
+            }
+        }
+    }
+
+    #[AsEventListener(FightTemplate::OnSkillActivationEvent)]
+    public function onSkillActivationEvent(BattleSkillActivationEvent $event): void
+    {
+        if (!$this->security->isGranted("ROLE_CHEATS_ENABLED")) return;
+
+        if ($event->skillName === "specialty") {
+            $specialtyId = $event->action->getParameter("specialty");
+            $specialtySkillKey = $event->action->getParameter("specialty_skill");
+            $specialtyEntity = $this->specialtyRepository->find($specialtyId);
+
+            $specialtySkills = $specialtyEntity->skills;
+            $specialtySkill = null;
+            if (isset($specialtySkills[$specialtySkillKey])) {
+                $specialtySkill = $specialtySkills[$specialtySkillKey];
+            }
+
+            $characterSpecialty = $this->getSpecialty($event->character, $specialtyEntity);
+
+            if (
+                $specialtyId === null || $specialtySkillKey === null || $specialtyEntity === null
+                || $specialtySkill === null || $characterSpecialty === null
+                || $characterSpecialty->uses < $specialtySkill->costs
+            ) {
+                $this->logger->warning("{$event->character}: Skill transfer was errornous", context: [
+                    "parameterId" => $specialtyId,
+                    "parameterSkillKey" => $specialtySkillKey,
+                    "specialtyEntity" => $specialtyEntity,
+                    "specialtySkill" => $specialtySkill,
+                    "specialtySkills" => $specialtySkills,
+                    "characterSpecialty" => $characterSpecialty,
+                ]);
+
+                $event->buff->addBuff($event->character, new Buff(
+                    id: "lotgd2.buff.DefaultFightTrait.SkillNotFound",
+                    name: "Skill Not Found",
+                    activatesAt: Buff::ACTIVATES_ON_ROUNDSTART,
+                    rounds: 1,
+                    startMessage: "You try to attack {{ badGuy.name }} using complicated movements, but nothing happens.",
+                ));
+
+                $event->stopPropagation();
+                return;
+            }
+
+            // Add proto buff to character
+            $protoBuff = $specialtySkill->buff;
+            $event->buff->addBuffFromPrototype($event->character, $protoBuff);
+
+            // Substract the costs from the uses
+            $characterSpecialty->uses -= $specialtySkill->costs;
+
+            $event->stopPropagation();
+        }
     }
 
     #[AsEventListener(Battle::OnAddFightActions)]
@@ -50,7 +454,7 @@ class SpecialtyHandler implements DiceBagAwareInterface
     }
 
     #[AsEventListener(FightTemplate::OnSkillActivationEvent)]
-    public function onSkillActivationEvent(BattleSkillActivationEvent $event): void
+    public function onCheatSkillActivationEvent(BattleSkillActivationEvent $event): void
     {
         if (!$this->security->isGranted("ROLE_CHEATS_ENABLED")) return;
 

--- a/src/Game/Scene/SceneRenderer.php
+++ b/src/Game/Scene/SceneRenderer.php
@@ -89,10 +89,11 @@ readonly class SceneRenderer
     /**
      * Internal helper method. Creates an action to switch scenes based on a connection.
      *
-     * @internal
      * @param Scene $scene
      * @param SceneConnection $sceneConnection
+     * @param ExpressionService $expressionService
      * @return ?Action
+     * @internal
      */
     public function createActionFromConnection(
         Scene $scene,

--- a/src/Game/Scene/SceneRenderer.php
+++ b/src/Game/Scene/SceneRenderer.php
@@ -107,14 +107,14 @@ readonly class SceneRenderer
             $action->title = $sceneConnection->sourceLabel ?? $sceneConnection->targetScene->title;
             $action->sceneId = $sceneConnection->targetScene;
 
-            if (!$expressionService->evaluate($sceneConnection->sourceExpression)) {
+            if (!$expressionService->evaluateBoolean($sceneConnection->sourceExpression)) {
                 $add =false;
             }
         } elseif ($sceneConnection->targetScene === $scene) {
             $action->title = $sceneConnection->targetLabel ?? $sceneConnection->sourceScene->title;
             $action->sceneId = $sceneConnection->sourceScene;
 
-            if (!$expressionService->evaluate($sceneConnection->targetExpression)) {
+            if (!$expressionService->evaluateBoolean($sceneConnection->targetExpression)) {
                 $add =false;
             }
         } else {

--- a/src/Repository/SpecialtyRepository.php
+++ b/src/Repository/SpecialtyRepository.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2\Repository;
+
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use LotGD2\Entity\Mapped\Specialty;
+
+/**
+ * @extends ServiceEntityRepository<Specialty>
+ */
+class SpecialtyRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Specialty::class);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace LotGD2;
+
+use LotGD2\Entity\Character\CharacterSpecialty;
+
+if (!function_exists("LotGD2\array_filter_class")) {
+    /**
+     * @template T of object
+     * @param list<mixed> $array
+     * @param class-string<T> $className
+     * @return list<T>
+     */
+    function array_filter_class(array $array, string $className): array
+    {
+        return array_filter($array, fn (mixed $value) => is_a($value, $className, allow_string: true));
+    }
+}

--- a/tests/Game/Scene/SceneRendererTest.php
+++ b/tests/Game/Scene/SceneRendererTest.php
@@ -153,7 +153,7 @@ class SceneRendererTest extends TestCase
         $actionService = $this->createStub(ActionService::class);
 
         $expressionService = $this->createMock(ExpressionService::class);
-        $expressionService->expects($this->once())->method("evaluate")->willReturn(true);
+        $expressionService->expects($this->once())->method("evaluateBoolean")->willReturn(true);
 
         $sceneRenderer = new SceneRenderer($sceneRepository, $diceBag, $actionService, $this->logger);
 
@@ -182,7 +182,7 @@ class SceneRendererTest extends TestCase
         $actionService = $this->createStub(ActionService::class);
 
         $expressionService = $this->createMock(ExpressionService::class);
-        $expressionService->expects($this->once())->method("evaluate")->willReturn(true);
+        $expressionService->expects($this->once())->method("evaluateBoolean")->willReturn(true);
 
         $sceneRenderer = new SceneRenderer($sceneRepository, $diceBag, $actionService, $this->logger);
 
@@ -212,7 +212,7 @@ class SceneRendererTest extends TestCase
         $diceBag = new DiceBag();
         $actionService = $this->createStub(ActionService::class);
         $expressionService = $this->createMock(ExpressionService::class);
-        $expressionService->expects($this->exactly(0))->method("evaluate")->willReturn(true);
+        $expressionService->expects($this->exactly(0))->method("evaluateBoolean")->willReturn(true);
 
         $sceneRenderer = new SceneRenderer($sceneRepository, $diceBag, $actionService, $this->logger);
 


### PR DESCRIPTION
This PR adds the missing parts to have specialties inside the game.

- Specialties are similar to Races as they can have a class adding more functionalities as well as a config, but this feature is so far not used.
- Specialties have a skills column containing a list of skills. Each Skill is a name, a cost and a ProtoBuff.
- Introduces the concept of a ProtoBuff. A ProtoBuff is related to a Buff, but accepts strings for most of the arguments. The strings are getting evaluated by the ExpressionService and allows _scaling_ of a buff.
- SpecialtyHandler allows to pick a new main specialty either if empty or if the current picked specialty "disappears" (eg, gets deleted from the database).
- Specialties are saved as CharacterSpecialty on a character with proficiency and current uses
- SpecialtyHandler adds on new days the uses according to the character's proficiency in that specialty. For the main specialties, it adds an extra use.
- SpecialtyHandler adds for all specialties a skill
- Expands the BattleSkillActivationEvent to provide the complete Action to access _more_ parameters in addition to just the skill name
- Adds processBuff events for round_start and round_end of a battle, so that regen and minions can also operate at these times. Does not apply to damage-dependent buffs.

Closes #23 